### PR TITLE
Simplify auto_normalize to deterministic defaults

### DIFF
--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -28,9 +28,7 @@
 #' label them as "QC" as the "group" in the sample information table.
 #' You can also use set `qc_name` to other names.
 #'
-#' When QC samples exist, [auto_normalize()] will compare various
-#' normalization methods and select the one that stabilizes QC samples the most.
-#' [auto_impute()] uses deterministic defaults based on sample count and
+#' [auto_normalize()] and [auto_impute()] use deterministic defaults based on
 #' experiment type, regardless of QC sample availability.
 #'
 #' @param exp A [glyexp::experiment()] containing glycoproteomics or
@@ -41,16 +39,10 @@
 #'   Can be NULL when no batch information is available.
 #' @param qc_name The name of QC samples in the `group_col` column. Default is "QC".
 #'   Only used when `group_col` is not NULL. Can be NULL when no QC samples are available.
-#' @param normalize_to_try Normalization functions to try. A list. Default includes:
-#'   - [normalize_median()]: median normalization
-#'   - [normalize_median_abs()]: absolute median normalization
-#'   - [normalize_total_area()]: total area mormalization
-#'   - [normalize_quantile()]: quantile normalization
-#'   - [normalize_loessf()]: LoessF normalization
-#'   - [normalize_loesscyc()]: LoessCyc normalization
-#'   - [normalize_rlr()]: RLR normalization
-#'   - [normalize_rlrma()]: RLRMA normalization
-#'   - [normalize_rlrmacyc()]: RLRMAcyc normalization
+#' @param normalize_to_try `r lifecycle::badge("deprecated")`
+#'   This parameter is no longer used and will be removed in a future release.
+#'   The automatic normalization strategy is now deterministic and does not
+#'   require user-specified methods to try.
 #' @param impute_to_try `r lifecycle::badge("deprecated")`
 #'   This parameter is no longer used and will be removed in a future release.
 #' @param remove_preset The preset for removing variables. Default is "discovery".
@@ -96,7 +88,6 @@ auto_clean <- function(
   checkmate::assert_string(group_col, null.ok = TRUE)
   checkmate::assert_string(batch_col, null.ok = TRUE)
   checkmate::assert_string(qc_name, null.ok = TRUE)
-  checkmate::assert_list(normalize_to_try, types = "function", null.ok = TRUE)
   checkmate::assert_choice(remove_preset, c("simple", "discovery", "biomarker"))
   checkmate::assert_number(batch_prop_threshold, lower = 0, upper = 1)
   checkmate::assert_flag(check_batch_confounding)
@@ -113,6 +104,14 @@ auto_clean <- function(
     ))
   }
 
+  if (!is.null(normalize_to_try)) {
+    lifecycle::deprecate_warn(
+      when = "0.14.0",
+      what = "auto_clean(normalize_to_try)",
+      details = "The automatic normalization strategy is now deterministic and does not require user-specified methods to try. The `normalize_to_try` parameter will be removed in a future release."
+    )
+  }
+
   if (!is.null(impute_to_try)) {
     lifecycle::deprecate_warn(
       when = "0.14.0",
@@ -124,7 +123,6 @@ auto_clean <- function(
   params <- list(
     group_col = group_col,
     qc_name = qc_name,
-    normalize_to_try = normalize_to_try,
     remove_preset = remove_preset,
     batch_prop_threshold = batch_prop_threshold,
     check_batch_confounding = check_batch_confounding,
@@ -143,10 +141,7 @@ auto_clean <- function(
   cli::cli_h2("Normalizing data")
   exp <- auto_normalize(
     exp,
-    params$group_col,
-    params$qc_name,
-    params$normalize_to_try,
-    info
+    group_col = params$group_col
   )
   cli::cli_alert_success("Normalization completed.")
   cli::cli_h2("Removing variables with too many missing values")
@@ -171,10 +166,7 @@ auto_clean <- function(
   cli::cli_h2("Normalizing data again")
   exp <- auto_normalize(
     exp,
-    params$group_col,
-    params$qc_name,
-    params$normalize_to_try,
-    info
+    group_col = params$group_col
   )
   cli::cli_alert_success("Normalization completed.")
   cli::cli_h2("Correcting batch effects")
@@ -211,10 +203,7 @@ auto_clean <- function(
   cli::cli_h2("Normalizing data")
   exp <- auto_normalize(
     exp,
-    params$group_col,
-    params$qc_name,
-    params$normalize_to_try,
-    info
+    group_col = params$group_col
   )
   cli::cli_alert_success("Normalization completed.")
   cli::cli_h2("Correcting batch effects")

--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -21,16 +21,6 @@
 #' - [auto_normalize()]
 #' - [auto_correct_batch_effect()]
 #'
-#' @details
-#' # QC samples
-#'
-#' If you have quality control (QC) samples,
-#' label them as "QC" as the "group" in the sample information table.
-#' You can also use set `qc_name` to other names.
-#'
-#' [auto_normalize()] and [auto_impute()] use deterministic defaults based on
-#' experiment type, regardless of QC sample availability.
-#'
 #' @param exp A [glyexp::experiment()] containing glycoproteomics or
 #'   glycomics data.
 #' @param group_col The column name in sample_info for groups. Default is "group".

--- a/R/auto-normalize.R
+++ b/R/auto-normalize.R
@@ -1,33 +1,27 @@
 #' Automatic Normalization
 #'
-#' This function automatically selects and applies the most suitable normalization method for the given dataset.
-#' If Quality Control (QC) samples are present, the method that best stabilizes them
-#' (i.e., yields the lowest median coefficient of variation) is chosen.
-#' Otherwise, it defaults to median normalization for glycoproteomics data,
-#' and total area normalization for glycomics data.
+#' This function automatically applies a deterministic default normalization
+#' method based on experiment type. Quality Control (QC) samples are not used
+#' to benchmark, select, or report normalization behavior.
 #'
 #' @details
-#' When QC samples are available, the function benchmarks all normalization methods in `to_try`
-#' and selects the one with the lowest median coefficient of variation (CV) among QC samples.
-#' Methods that fail are skipped with a warning.
+#' The automatic strategy uses these defaults:
+#' - `glycomics`: [normalize_total_area()].
+#' - `glycoproteomics`: [normalize_median()].
+#' - missing or other experiment types: [normalize_median()].
 #'
 #' @param exp An [glyexp::experiment()].
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
-#' @param qc_name The name of QC samples in the `group_col` column. Default is "QC".
-#'   Only used when `group_col` is not NULL. Can be NULL when no QC samples are available.
-#' @param to_try Normalization functions to try when QC samples are present. A list. Default includes:
-#'   - [normalize_median()]: median normalization
-#'   - [normalize_median_abs()]: absolute median normalization
-#'   - [normalize_total_area()]: total area normalization
-#'   - [normalize_quantile()]: quantile normalization
-#'   - [normalize_loessf()]: LoessF normalization
-#'   - [normalize_loesscyc()]: LoessCyc normalization
-#'   - [normalize_median_quotient()]: median quotient normalization
-#'   - [normalize_rlr()]: Robust Linear Regression normalization
-#'   - [normalize_rlrma()]: Robust Linear Regression with Median Adjustment normalization
-#'   - [normalize_rlrmacyc()]: Robust Linear Regression with Median Adjustment and Cyclic normalization
-#' @param info Internal parameter used by [auto_clean()].
+#' @param qc_name `r lifecycle::badge("deprecated")` This function no longer
+#'   uses this argument.
+#'   This parameter is ignored and will be removed in a future release.
+#' @param to_try `r lifecycle::badge("deprecated")`
+#'   This parameter is no longer used and will be removed in a future release.
+#'   The automatic strategy is now deterministic and does not require
+#'   user-specified methods to try.
+#' @param info Internal parameter used by [auto_clean()]. Ignored by
+#'   [auto_normalize()].
 #'
 #' @returns The normalized experiment.
 #' @examples
@@ -44,134 +38,67 @@ auto_normalize <- function(
   # Check arguments
   checkmate::assert_class(exp, "glyexp_experiment")
   checkmate::assert_string(group_col, null.ok = TRUE)
-  checkmate::assert_string(qc_name, null.ok = TRUE)
-  checkmate::assert_list(to_try, types = "function", null.ok = TRUE)
 
-  # Default normalization methods to try
-  if (is.null(to_try)) {
-    to_try <- list(
-      normalize_median = normalize_median,
-      normalize_median_abs = normalize_median_abs,
-      normalize_total_area = normalize_total_area,
-      normalize_quantile = normalize_quantile,
-      normalize_median_quotient = normalize_median_quotient,
-      normalize_loessf = normalize_loessf,
-      normalize_loesscyc = normalize_loesscyc,
-      normalize_rlr = normalize_rlr,
-      normalize_rlrma = normalize_rlrma,
-      normalize_rlrmacyc = normalize_rlrmacyc
+  if (!identical(qc_name, "QC")) {
+    lifecycle::deprecate_warn(
+      when = "0.14.0",
+      what = "auto_normalize(qc_name)",
+      details = "This function no longer uses the `qc_name` parameter and it will be removed in a future release."
+    )
+  }
+  if (!is.null(to_try)) {
+    lifecycle::deprecate_warn(
+      when = "0.14.0",
+      what = "auto_normalize(to_try)",
+      details = "The automatic normalization strategy is now deterministic and does not require user-specified methods to try. The `to_try` parameter will be removed in a future release."
     )
   }
 
-  # Get experiment inspection
-  if (is.null(info)) {
-    info <- inspect_experiment(exp, group_col = group_col, qc_name = qc_name)
-  }
-
-  if (info$has_qc) {
-    .auto_normalize_with_qc(exp, to_try, info)
-  } else {
-    .auto_normalize_default(exp)
-  }
+  .auto_normalize_default(exp)
 }
 
-.auto_normalize_with_qc <- function(exp, to_try, info) {
-  cli::cli_alert_info(
-    "QC samples found. Choosing the best normalization method based on QC samples."
-  )
-
-  best_method <- NULL
-  best_cv <- Inf
-  best_exp <- NULL
-
-  # Calculate CV for raw data
-  raw_cv <- .calc_median_cv(exp$expr_mat[, info$qc_samples, drop = FALSE])
-  cli::cli_ul("Raw data: Median CV = {.val {signif(raw_cv, 4)}}")
-
-  for (method_name in names(to_try)) {
-    method <- to_try[[method_name]]
-
-    # Try normalization
-    tryCatch(
-      {
-        normed_exp <- method(exp)
-        normed_mat <- normed_exp$expr_mat[, info$qc_samples, drop = FALSE]
-        cv <- .calc_median_cv(normed_mat)
-
-        cli::cli_ul(
-          "Method {.val {method_name}}: Median CV = {.val {signif(cv, 4)}}"
-        )
-
-        if (cv < best_cv) {
-          best_cv <- cv
-          best_method <- method_name
-          best_exp <- normed_exp
-        }
-      },
-      error = function(e) {
-        cli::cli_alert_warning(
-          "Method {.val {method_name}} failed: {e$message}"
-        )
-      }
-    )
-  }
-
-  if (!is.null(best_exp)) {
-    cli::cli_alert_success(
-      "Best method: {.val {best_method}} with Median CV = {.val {signif(best_cv, 4)}}"
-    )
-    best_exp
-  } else {
-    cli::cli_alert_warning(
-      "All normalization methods failed. Returning original experiment."
-    )
-    exp
-  }
-}
-
+#' Apply the deterministic automatic normalization strategy
+#'
+#' @param exp An [glyexp::experiment()].
+#'
+#' @returns The normalized experiment.
+#' @noRd
 .auto_normalize_default <- function(exp) {
+  strategy <- .choose_auto_normalize_strategy(glyexp::get_exp_type(exp))
+
   cli::cli_alert_info(
-    "No QC samples found. Using default normalization method based on experiment type."
+    "Using default normalization method for {.val {strategy$exp_type}}: {.fn {strategy$method_name}}."
   )
 
-  exp_type <- exp$meta_data$exp_type
+  switch(
+    strategy$method_name,
+    normalize_total_area = normalize_total_area(exp),
+    normalize_median = normalize_median(exp)
+  )
+}
+
+#' Choose the deterministic automatic normalization strategy
+#'
+#' @param exp_type Experiment type from [glyexp::get_exp_type()].
+#'
+#' @returns A list containing the reported experiment type and method name.
+#' @noRd
+.choose_auto_normalize_strategy <- function(exp_type) {
+  checkmate::assert_string(exp_type, null.ok = TRUE)
+
+  if (identical(exp_type, "glycomics")) {
+    return(list(
+      exp_type = "glycomics",
+      method_name = "normalize_total_area"
+    ))
+  }
 
   if (is.null(exp_type)) {
-    # Fallback if exp_type is missing (though it should be there)
-    cli::cli_alert_warning(
-      "Experiment type not found. Defaulting to median normalization."
-    )
-    return(normalize_median(exp))
+    exp_type <- "missing experiment type"
   }
 
-  if (exp_type == "glycomics") {
-    cli::cli_alert_info(
-      "Experiment type is {.val glycomics} with {.val nrow(exp)} glycans."
-    )
-    normalize_total_area(exp)
-  } else {
-    # Default for glycoproteomics and others
-    cli::cli_alert_info(
-      "Experiment type is {.val {exp_type}}. Using {.fn normalize_median}."
-    )
-    normalize_median(exp)
-  }
-}
-
-.calc_median_cv <- function(mat) {
-  # Calculate CV for each feature: sd / mean
-  # Handle zeros and NAs
-  row_means <- rowMeans(mat, na.rm = TRUE)
-  row_sds <- apply(mat, 1, stats::sd, na.rm = TRUE)
-
-  cvs <- row_sds / row_means
-
-  # Remove infinite or NaN CVs (e.g. mean = 0)
-  cvs <- cvs[is.finite(cvs)]
-
-  if (length(cvs) == 0) {
-    return(NA)
-  }
-
-  stats::median(cvs, na.rm = TRUE)
+  list(
+    exp_type = exp_type,
+    method_name = "normalize_median"
+  )
 }

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -31,18 +31,10 @@ Can be NULL when no batch information is available.}
 \item{qc_name}{The name of QC samples in the \code{group_col} column. Default is "QC".
 Only used when \code{group_col} is not NULL. Can be NULL when no QC samples are available.}
 
-\item{normalize_to_try}{Normalization functions to try. A list. Default includes:
-\itemize{
-\item \code{\link[=normalize_median]{normalize_median()}}: median normalization
-\item \code{\link[=normalize_median_abs]{normalize_median_abs()}}: absolute median normalization
-\item \code{\link[=normalize_total_area]{normalize_total_area()}}: total area mormalization
-\item \code{\link[=normalize_quantile]{normalize_quantile()}}: quantile normalization
-\item \code{\link[=normalize_loessf]{normalize_loessf()}}: LoessF normalization
-\item \code{\link[=normalize_loesscyc]{normalize_loesscyc()}}: LoessCyc normalization
-\item \code{\link[=normalize_rlr]{normalize_rlr()}}: RLR normalization
-\item \code{\link[=normalize_rlrma]{normalize_rlrma()}}: RLRMA normalization
-\item \code{\link[=normalize_rlrmacyc]{normalize_rlrmacyc()}}: RLRMAcyc normalization
-}}
+\item{normalize_to_try}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+This parameter is no longer used and will be removed in a future release.
+The automatic normalization strategy is now deterministic and does not
+require user-specified methods to try.}
 
 \item{impute_to_try}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 This parameter is no longer used and will be removed in a future release.}
@@ -103,9 +95,7 @@ If you have quality control (QC) samples,
 label them as "QC" as the "group" in the sample information table.
 You can also use set \code{qc_name} to other names.
 
-When QC samples exist, \code{\link[=auto_normalize]{auto_normalize()}} will compare various
-normalization methods and select the one that stabilizes QC samples the most.
-\code{\link[=auto_impute]{auto_impute()}} uses deterministic defaults based on sample count and
+\code{\link[=auto_normalize]{auto_normalize()}} and \code{\link[=auto_impute]{auto_impute()}} use deterministic defaults based on
 experiment type, regardless of QC sample availability.
 }
 

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -90,15 +90,6 @@ For glycoproteomics data, this function calls these functions in sequence:
 \item \code{\link[=auto_correct_batch_effect]{auto_correct_batch_effect()}}
 }
 }
-\section{QC samples}{
-If you have quality control (QC) samples,
-label them as "QC" as the "group" in the sample information table.
-You can also use set \code{qc_name} to other names.
-
-\code{\link[=auto_normalize]{auto_normalize()}} and \code{\link[=auto_impute]{auto_impute()}} use deterministic defaults based on
-experiment type, regardless of QC sample availability.
-}
-
 \examples{
 library(glyexp)
 exp <- real_experiment

--- a/man/auto_normalize.Rd
+++ b/man/auto_normalize.Rd
@@ -18,39 +18,33 @@ auto_normalize(
 \item{group_col}{The column name in sample_info for groups. Default is "group".
 Can be NULL when no group information is available.}
 
-\item{qc_name}{The name of QC samples in the \code{group_col} column. Default is "QC".
-Only used when \code{group_col} is not NULL. Can be NULL when no QC samples are available.}
+\item{qc_name}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This function no longer
+uses this argument.
+This parameter is ignored and will be removed in a future release.}
 
-\item{to_try}{Normalization functions to try when QC samples are present. A list. Default includes:
-\itemize{
-\item \code{\link[=normalize_median]{normalize_median()}}: median normalization
-\item \code{\link[=normalize_median_abs]{normalize_median_abs()}}: absolute median normalization
-\item \code{\link[=normalize_total_area]{normalize_total_area()}}: total area normalization
-\item \code{\link[=normalize_quantile]{normalize_quantile()}}: quantile normalization
-\item \code{\link[=normalize_loessf]{normalize_loessf()}}: LoessF normalization
-\item \code{\link[=normalize_loesscyc]{normalize_loesscyc()}}: LoessCyc normalization
-\item \code{\link[=normalize_median_quotient]{normalize_median_quotient()}}: median quotient normalization
-\item \code{\link[=normalize_rlr]{normalize_rlr()}}: Robust Linear Regression normalization
-\item \code{\link[=normalize_rlrma]{normalize_rlrma()}}: Robust Linear Regression with Median Adjustment normalization
-\item \code{\link[=normalize_rlrmacyc]{normalize_rlrmacyc()}}: Robust Linear Regression with Median Adjustment and Cyclic normalization
-}}
+\item{to_try}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+This parameter is no longer used and will be removed in a future release.
+The automatic strategy is now deterministic and does not require
+user-specified methods to try.}
 
-\item{info}{Internal parameter used by \code{\link[=auto_clean]{auto_clean()}}.}
+\item{info}{Internal parameter used by \code{\link[=auto_clean]{auto_clean()}}. Ignored by
+\code{\link[=auto_normalize]{auto_normalize()}}.}
 }
 \value{
 The normalized experiment.
 }
 \description{
-This function automatically selects and applies the most suitable normalization method for the given dataset.
-If Quality Control (QC) samples are present, the method that best stabilizes them
-(i.e., yields the lowest median coefficient of variation) is chosen.
-Otherwise, it defaults to median normalization for glycoproteomics data,
-and total area normalization for glycomics data.
+This function automatically applies a deterministic default normalization
+method based on experiment type. Quality Control (QC) samples are not used
+to benchmark, select, or report normalization behavior.
 }
 \details{
-When QC samples are available, the function benchmarks all normalization methods in \code{to_try}
-and selects the one with the lowest median coefficient of variation (CV) among QC samples.
-Methods that fail are skipped with a warning.
+The automatic strategy uses these defaults:
+\itemize{
+\item \code{glycomics}: \code{\link[=normalize_total_area]{normalize_total_area()}}.
+\item \code{glycoproteomics}: \code{\link[=normalize_median]{normalize_median()}}.
+\item missing or other experiment types: \code{\link[=normalize_median]{normalize_median()}}.
+}
 }
 \examples{
 library(glyexp)

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -6,8 +6,7 @@
       
       -- Normalizing data --
       
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "glycoproteomics". Using `normalize_median()`.
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
       v Normalization completed.
       
       -- Removing variables with too many missing values --
@@ -29,8 +28,7 @@
       
       -- Normalizing data again --
       
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "glycoproteomics". Using `normalize_median()`.
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -46,19 +44,7 @@
       
       -- Normalizing data --
       
-      i QC samples found. Choosing the best normalization method based on QC samples.
-      * Raw data: Median CV = CV_VALUE
-      * Method "normalize_median": Median CV = CV_VALUE
-      * Method "normalize_median_abs": Median CV = CV_VALUE
-      * Method "normalize_total_area": Median CV = CV_VALUE
-      * Method "normalize_quantile": Median CV = CV_VALUE
-      * Method "normalize_median_quotient": Median CV = CV_VALUE
-      * Method "normalize_loessf": Median CV = CV_VALUE
-      * Method "normalize_loesscyc": Median CV = CV_VALUE
-      * Method "normalize_rlr": Median CV = CV_VALUE
-      * Method "normalize_rlrma": Median CV = CV_VALUE
-      * Method "normalize_rlrmacyc": Median CV = CV_VALUE
-      v Best method: "BEST_METHOD" with Median CV = CV_VALUE
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
       v Normalization completed.
       
       -- Removing variables with too many missing values --
@@ -80,19 +66,7 @@
       
       -- Normalizing data again --
       
-      i QC samples found. Choosing the best normalization method based on QC samples.
-      * Raw data: Median CV = CV_VALUE
-      * Method "normalize_median": Median CV = CV_VALUE
-      * Method "normalize_median_abs": Median CV = CV_VALUE
-      * Method "normalize_total_area": Median CV = CV_VALUE
-      * Method "normalize_quantile": Median CV = CV_VALUE
-      * Method "normalize_median_quotient": Median CV = CV_VALUE
-      * Method "normalize_loessf": Median CV = CV_VALUE
-      * Method "normalize_loesscyc": Median CV = CV_VALUE
-      * Method "normalize_rlr": Median CV = CV_VALUE
-      * Method "normalize_rlrma": Median CV = CV_VALUE
-      * Method "normalize_rlrmacyc": Median CV = CV_VALUE
-      v Best method: "BEST_METHOD" with Median CV = CV_VALUE
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -108,8 +82,7 @@
       
       -- Normalizing data --
       
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "glycoproteomics". Using `normalize_median()`.
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
       v Normalization completed.
       
       -- Removing variables with too many missing values --
@@ -131,8 +104,7 @@
       
       -- Normalizing data again --
       
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "glycoproteomics". Using `normalize_median()`.
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -160,8 +132,7 @@
       
       -- Normalizing data --
       
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "glycomics" with "nrow(exp)" glycans.
+      i Using default normalization method for "glycomics": `normalize_total_area()`.
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -189,19 +160,7 @@
       
       -- Normalizing data --
       
-      i QC samples found. Choosing the best normalization method based on QC samples.
-      * Raw data: Median CV = CV_VALUE
-      * Method "normalize_median": Median CV = CV_VALUE
-      * Method "normalize_median_abs": Median CV = CV_VALUE
-      * Method "normalize_total_area": Median CV = CV_VALUE
-      * Method "normalize_quantile": Median CV = CV_VALUE
-      * Method "normalize_median_quotient": Median CV = CV_VALUE
-      * Method "normalize_loessf": Median CV = CV_VALUE
-      * Method "normalize_loesscyc": Median CV = CV_VALUE
-      * Method "normalize_rlr": Median CV = CV_VALUE
-      * Method "normalize_rlrma": Median CV = CV_VALUE
-      * Method "normalize_rlrmacyc": Median CV = CV_VALUE
-      v Best method: "BEST_METHOD" with Median CV = CV_VALUE
+      i Using default normalization method for "glycomics": `normalize_total_area()`.
       v Normalization completed.
       
       -- Correcting batch effects --

--- a/tests/testthat/_snaps/auto-normalize.md
+++ b/tests/testthat/_snaps/auto-normalize.md
@@ -1,43 +1,37 @@
-# auto_normalize works with QC samples
+# auto_normalize uses deterministic defaults with QC samples
 
     Code
-      normed <- auto_normalize(exp, group_col = "group", qc_name = "QC")
+      normed <- auto_normalize(exp, group_col = "group", qc_name = "QC", to_try = list(
+        normalize_median = function(x) stop("must not be called")))
+    Condition
+      Warning:
+      The `to_try` argument of `auto_normalize()` is deprecated as of glyclean 0.14.0.
+      i The automatic normalization strategy is now deterministic and does not require user-specified methods to try. The `to_try` parameter will be removed in a future release.
     Message
-      i QC samples found. Choosing the best normalization method based on QC samples.
-      * Raw data: Median CV = CV_VALUE
-      * Method "normalize_median": Median CV = CV_VALUE
-      * Method "normalize_median_abs": Median CV = CV_VALUE
-      * Method "normalize_total_area": Median CV = CV_VALUE
-      * Method "normalize_quantile": Median CV = CV_VALUE
-      * Method "normalize_median_quotient": Median CV = CV_VALUE
-      * Method "normalize_loessf": Median CV = CV_VALUE
-      * Method "normalize_loesscyc": Median CV = CV_VALUE
-      * Method "normalize_rlr": Median CV = CV_VALUE
-      * Method "normalize_rlrma": Median CV = CV_VALUE
-      * Method "normalize_rlrmacyc": Median CV = CV_VALUE
-      v Best method: "BEST_METHOD" with Median CV = CV_VALUE
+      i Using default normalization method for "glycomics": `normalize_total_area()`.
 
 # auto_normalize handles NULL qc_name
 
     Code
       normed <- auto_normalize(exp, group_col = "group", qc_name = NULL)
+    Condition
+      Warning:
+      The `qc_name` argument of `auto_normalize()` is deprecated as of glyclean 0.14.0.
+      i This function no longer uses the `qc_name` parameter and it will be removed in a future release.
     Message
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "others". Using `normalize_median()`.
+      i Using default normalization method for "others": `normalize_median()`.
 
 # auto_normalize works for glycoproteomics without QC
 
     Code
       auto <- auto_normalize(exp, group_col = NULL)
     Message
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "glycoproteomics". Using `normalize_median()`.
+      i Using default normalization method for "glycoproteomics": `normalize_median()`.
 
 # auto_normalize falls back to median for others
 
     Code
       auto <- auto_normalize(exp, group_col = NULL)
     Message
-      i No QC samples found. Using default normalization method based on experiment type.
-      i Experiment type is "others". Using `normalize_median()`.
+      i Using default normalization method for "others": `normalize_median()`.
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -59,9 +59,5 @@ sanitize_cv_snapshot <- function(x) {
     stringr::str_replace_all(
       "CV = [-+]?\\d*\\.?\\d+(?:e[-+]?\\d+)?",
       "CV = CV_VALUE"
-    ) |>
-    stringr::str_replace_all(
-      'Best method: ".*?"',
-      'Best method: "BEST_METHOD"'
     )
 }

--- a/tests/testthat/test-auto-normalize.R
+++ b/tests/testthat/test-auto-normalize.R
@@ -1,21 +1,30 @@
-test_that("auto_normalize works with QC samples", {
-  # Create a simple experiment
+test_that("auto_normalize uses deterministic defaults with QC samples", {
   exp <- simple_exp(10, 10)
-
-  # Add QC samples
+  exp$meta_data$exp_type <- "glycomics"
+  exp$meta_data$glycan_type <- "N"
   exp$sample_info$group <- c(rep("A", 4), rep("B", 4), rep("QC", 2))
 
-  # Make QC samples have low variance after median normalization
-  # but high variance otherwise (simulated)
-  # Actually, it's hard to simulate "perfectly" for one method without running them.
-  # But we can just check if it runs and returns a valid experiment.
+  called <- NULL
+  testthat::local_mocked_bindings(
+    normalize_total_area = function(x) {
+      called <<- "normalize_total_area"
+      x$expr_mat <- x$expr_mat * 2
+      x
+    },
+    .package = "glyclean"
+  )
 
-  # Let's just verify it runs and picks a method
   expect_snapshot(
-    normed <- auto_normalize(exp, group_col = "group", qc_name = "QC"),
+    normed <- auto_normalize(
+      exp,
+      group_col = "group",
+      qc_name = "QC",
+      to_try = list(normalize_median = function(x) stop("must not be called"))
+    ),
     transform = sanitize_cv_snapshot
   )
-  expect_s3_class(normed, "glyexp_experiment")
+  expect_equal(called, "normalize_total_area")
+  expect_equal(normed$expr_mat, exp$expr_mat * 2)
 })
 
 test_that("auto_normalize handles NULL qc_name", {
@@ -23,7 +32,8 @@ test_that("auto_normalize handles NULL qc_name", {
   exp$sample_info$group <- c(rep("A", 4), rep("B", 4), rep("QC", 2))
 
   expect_snapshot(
-    normed <- auto_normalize(exp, group_col = "group", qc_name = NULL)
+    normed <- auto_normalize(exp, group_col = "group", qc_name = NULL),
+    transform = sanitize_cv_snapshot
   )
   expect_s3_class(normed, "glyexp_experiment")
 })

--- a/vignettes/glyclean.Rmd
+++ b/vignettes/glyclean.Rmd
@@ -124,15 +124,15 @@ As you can see, `auto_clean()` calls the following functions in sequence:
 - `auto_aggregate()`: Automatically aggregate the data
 - `auto_correct_batch_effect()`: Automatically correct the batch effects
 
-These functions automatically choose the best method for the given dataset.
+These functions apply deterministic defaults for the given dataset.
 
 **How `auto_normalize()` works:**
 
-- **When QC samples are available**: All normalization methods are benchmarked, and the one with the lowest median coefficient of variation (CV) among QC samples is selected.
+- **When QC samples are available**: QC samples do not change the automatic method choice and are not used for normalization diagnostics.
 
-- **For glycomics data without QC samples**: Total area normalization is applied first, followed by CLR transformation (for ≤50 glycans) or ALR transformation (for >50 glycans), following the best practices from DOI: 10.1038/s41467-025-56249-3.
+- **For glycomics data**: Total area normalization is used as the default.
 
-- **For glycoproteomics data without QC samples**: Median normalization is used as the default.
+- **For glycoproteomics data and other experiment types**: Median normalization is used as the default.
 
 You can make a custom pipeline by calling these functions in different orders:
 


### PR DESCRIPTION
## Summary
- Remove QC-driven benchmarking from `auto_normalize()` and make it apply a deterministic experiment-type default only.
- Deprecate `qc_name` and `to_try` in `auto_normalize()`, matching the automatic-path cleanup in `auto_clean()`.
- Update tests, snapshots, Rd files, and vignette wording to reflect the new behavior.

## Testing
- Added and updated unit tests for deterministic normalization and deprecated-argument handling.
- Refreshed snapshots and documentation.
- Ran the full package test suite successfully.

Closes #7