### PR TITLE
Deprecate qc_name in auto_clean and simplify inspect_experiment

### DIFF
--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -27,8 +27,9 @@
 #'   Can be NULL when no group information is available.
 #' @param batch_col The column name in sample_info for batches. Default is "batch".
 #'   Can be NULL when no batch information is available.
-#' @param qc_name The name of QC samples in the `group_col` column. Default is "QC".
-#'   Only used when `group_col` is not NULL. Can be NULL when no QC samples are available.
+#' @param qc_name `r lifecycle::badge("deprecated")` This function no longer
+#'   uses QC sample information.
+#'   This parameter is ignored and will be removed in a future release.
 #' @param normalize_to_try `r lifecycle::badge("deprecated")`
 #'   This parameter is no longer used and will be removed in a future release.
 #'   The automatic normalization strategy is now deterministic and does not
@@ -77,7 +78,6 @@ auto_clean <- function(
   checkmate::assert_class(exp, "glyexp_experiment")
   checkmate::assert_string(group_col, null.ok = TRUE)
   checkmate::assert_string(batch_col, null.ok = TRUE)
-  checkmate::assert_string(qc_name, null.ok = TRUE)
   checkmate::assert_choice(remove_preset, c("simple", "discovery", "biomarker"))
   checkmate::assert_number(batch_prop_threshold, lower = 0, upper = 1)
   checkmate::assert_flag(check_batch_confounding)
@@ -110,16 +110,23 @@ auto_clean <- function(
     )
   }
 
+  if (!identical(qc_name, "QC")) {
+    lifecycle::deprecate_warn(
+      when = "0.14.0",
+      what = "auto_clean(qc_name)",
+      details = "This function no longer uses QC sample information and the `qc_name` parameter will be removed in a future release."
+    )
+  }
+
   params <- list(
     group_col = group_col,
-    qc_name = qc_name,
     remove_preset = remove_preset,
     batch_prop_threshold = batch_prop_threshold,
     check_batch_confounding = check_batch_confounding,
     batch_confounding_threshold = batch_confounding_threshold,
     standardize_variable = standardize_variable
   )
-  info <- inspect_experiment(exp, group_col = group_col, qc_name = qc_name)
+  info <- inspect_experiment(exp, group_col = group_col)
   switch(
     glyexp::get_exp_type(exp),
     glycoproteomics = .auto_clean_glycoproteomics(exp, params, info),

--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -137,10 +137,9 @@ auto_clean <- function(
   cli::cli_h2("Removing variables with too many missing values")
   exp <- auto_remove(
     exp,
-    params$remove_preset,
-    params$group_col,
-    params$qc_name,
-    info
+    preset = params$remove_preset,
+    group_col = params$group_col,
+    info = info
   )
   cli::cli_alert_success("Variable removal completed.")
   cli::cli_h2("Imputing missing values")
@@ -177,10 +176,9 @@ auto_clean <- function(
   cli::cli_h2("Removing variables with too many missing values")
   exp <- auto_remove(
     exp,
-    params$remove_preset,
-    params$group_col,
-    params$qc_name,
-    info
+    preset = params$remove_preset,
+    group_col = params$group_col,
+    info = info
   )
   cli::cli_alert_success("Variable removal completed.")
   cli::cli_h2("Imputing missing values")

--- a/R/auto-remove.R
+++ b/R/auto-remove.R
@@ -9,15 +9,13 @@
 #' - "biomarker": more strict, remove variables with more than 40% missing values,
 #'   and ensure less than 60% of missing values in all groups.
 #'
-#' QC samples will not be considered in the removal process.
-#'
 #' @param exp A glyexp_experiment object.
 #' @param preset One of "simple", "discovery", or "biomarker".
 #'   Default "discovery" if group information is available, otherwise "simple".
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
-#' @param qc_name The name of QC samples in the `group_col` column. Default is "QC".
-#'   Only used when `group_col` is not NULL. Can be NULL when no QC samples are available.
+#' @param qc_name `r lifecycle::badge("deprecated")` This function no longer uses QC sample information.
+#'   This parameter is ignored and will be removed in a future release.
 #' @param info Internal parameter used by [auto_clean()].
 #'
 #' @returns A modified [glyexp::experiment()] object.
@@ -38,64 +36,47 @@ auto_remove <- function(
   checkmate::assert_class(exp, "glyexp_experiment")
   checkmate::assert_choice(preset, c("simple", "discovery", "biomarker"))
   checkmate::assert_string(group_col, null.ok = TRUE)
-  checkmate::assert_string(qc_name, null.ok = TRUE)
+
+  if (!identical(qc_name, "QC")) {
+    lifecycle::deprecate_warn(
+      when = "0.14.0",
+      what = "auto_remove(qc_name)",
+      details = "This function no longer uses QC sample information and the `qc_name` parameter will be removed in a future release."
+    )
+  }
 
   if (is.null(info)) {
-    info <- inspect_experiment(exp, group_col = group_col, qc_name = qc_name)
-  }
-
-  # Identify samples to use (exclude QC)
-  all_samples <- exp$sample_info$sample
-  if (info$has_qc) {
-    samples_to_use <- setdiff(all_samples, info$qc_samples)
-    cli::cli_alert_info(
-      "QC samples found. Excluding {.val {length(info$qc_samples)}} QC samples from removal process."
-    )
+    has_group <- !is.null(group_col) && group_col %in% colnames(exp$sample_info)
   } else {
-    samples_to_use <- all_samples
-    cli::cli_alert_info("No QC samples found. Using all samples.")
+    has_group <- isTRUE(info$has_group)
   }
 
-  if (length(samples_to_use) == 0) {
-    cli::cli_abort("No samples left after excluding QC samples.")
-  }
-
-  # Create a subset experiment for calculation
-  exp_sub <- exp
-  exp_sub$expr_mat <- exp$expr_mat[, samples_to_use, drop = FALSE]
-  exp_sub$sample_info <- exp$sample_info[
-    exp$sample_info$sample %in% samples_to_use,
-    ,
-    drop = FALSE
-  ]
-
-  # Drop unused levels in group column if present to avoid empty groups in removal functions
-  if (info$has_group && is.factor(exp_sub$sample_info[[group_col]])) {
-    exp_sub$sample_info[[group_col]] <- droplevels(exp_sub$sample_info[[
+  exp_filtered <- exp
+  if (has_group && is.factor(exp_filtered$sample_info[[group_col]])) {
+    exp_filtered$sample_info[[group_col]] <- droplevels(exp_filtered$sample_info[[
       group_col
     ]])
   }
 
-  # Determine group column to use
-  use_group_col <- if (info$has_group) group_col else NULL
+  use_group_col <- if (has_group) group_col else NULL
 
   cli::cli_alert_info("Applying preset {.val {preset}}...")
 
   if (preset == "simple") {
-    exp_sub <- suppressMessages(remove_rare(exp_sub, prop = 0.5, min_n = 1))
+    exp_filtered <- suppressMessages(remove_rare(exp_filtered, prop = 0.5, min_n = 1))
   } else if (preset == "discovery") {
-    exp_sub <- suppressMessages(remove_rare(exp_sub, prop = 0.8, min_n = 1))
-    exp_sub <- suppressMessages(remove_rare(
-      exp_sub,
+    exp_filtered <- suppressMessages(remove_rare(exp_filtered, prop = 0.8, min_n = 1))
+    exp_filtered <- suppressMessages(remove_rare(
+      exp_filtered,
       prop = 0.5,
       by = use_group_col,
       strict = FALSE,
       min_n = 1
     ))
   } else if (preset == "biomarker") {
-    exp_sub <- suppressMessages(remove_rare(exp_sub, prop = 0.4, min_n = 1))
-    exp_sub <- suppressMessages(remove_rare(
-      exp_sub,
+    exp_filtered <- suppressMessages(remove_rare(exp_filtered, prop = 0.4, min_n = 1))
+    exp_filtered <- suppressMessages(remove_rare(
+      exp_filtered,
       prop = 0.6,
       by = use_group_col,
       strict = TRUE,
@@ -103,8 +84,7 @@ auto_remove <- function(
     ))
   }
 
-  # Apply removal to original experiment
-  kept_vars <- rownames(exp_sub$expr_mat)
+  kept_vars <- rownames(exp_filtered$expr_mat)
   n_before <- nrow(exp$expr_mat)
   n_after <- length(kept_vars)
   n_removed <- n_before - n_after

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -2,42 +2,14 @@
 #'
 #' @param exp An [glyexp::experiment()].
 #' @param group_col The column name in sample_info for groups. Default is "group".
-#' @param qc_name The name of QC samples in the `group_col` column. Default is "QC".
-#'   Only used when `group_col` is not NULL.
 #'
 #' @returns A list of metadata for automatic cleaning.
 #' @noRd
-inspect_experiment <- function(exp, group_col = "group", qc_name = "QC") {
+inspect_experiment <- function(exp, group_col = "group") {
   checkmate::assert_class(exp, "glyexp_experiment")
   checkmate::assert_string(group_col, null.ok = TRUE)
-  checkmate::assert_string(qc_name, null.ok = TRUE)
 
-  res <- list()
-
-  # has_group: whether the experiment has group information
-  if (!is.null(group_col) && group_col %in% colnames(exp$sample_info)) {
-    res$has_group <- TRUE
-  } else {
-    res$has_group <- FALSE
-  }
-
-  # has_qc: whether the experiment has QC samples
-  if (is.null(qc_name)) {
-    res$has_qc <- FALSE
-  } else if (res$has_group && qc_name %in% exp$sample_info[[group_col]]) {
-    res$has_qc <- TRUE
-  } else {
-    res$has_qc <- FALSE
-  }
-
-  # qc_samples: sample names of QC samples, NULL if no QC samples
-  if (res$has_qc) {
-    res$qc_samples <- exp$sample_info[["sample"]][
-      exp$sample_info[[group_col]] == qc_name
-    ]
-  } else {
-    res$qc_samples <- NULL
-  }
-
-  res
+  list(
+    has_group = !is.null(group_col) && group_col %in% colnames(exp$sample_info)
+  )
 }

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -28,8 +28,9 @@ Can be NULL when no group information is available.}
 \item{batch_col}{The column name in sample_info for batches. Default is "batch".
 Can be NULL when no batch information is available.}
 
-\item{qc_name}{The name of QC samples in the \code{group_col} column. Default is "QC".
-Only used when \code{group_col} is not NULL. Can be NULL when no QC samples are available.}
+\item{qc_name}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This function no longer
+uses QC sample information.
+This parameter is ignored and will be removed in a future release.}
 
 \item{normalize_to_try}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 This parameter is no longer used and will be removed in a future release.

--- a/man/auto_remove.Rd
+++ b/man/auto_remove.Rd
@@ -21,8 +21,8 @@ Default "discovery" if group information is available, otherwise "simple".}
 \item{group_col}{The column name in sample_info for groups. Default is "group".
 Can be NULL when no group information is available.}
 
-\item{qc_name}{The name of QC samples in the \code{group_col} column. Default is "QC".
-Only used when \code{group_col} is not NULL. Can be NULL when no QC samples are available.}
+\item{qc_name}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This function no longer uses QC sample information.
+This parameter is ignored and will be removed in a future release.}
 
 \item{info}{Internal parameter used by \code{\link[=auto_clean]{auto_clean()}}.}
 }
@@ -39,8 +39,6 @@ but ensure less than 50\% of missing values in at least one group.
 \item "biomarker": more strict, remove variables with more than 40\% missing values,
 and ensure less than 60\% of missing values in all groups.
 }
-
-QC samples will not be considered in the removal process.
 }
 \examples{
 library(glyexp)

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -11,7 +11,6 @@
       
       -- Removing variables with too many missing values --
       
-      i No QC samples found. Using all samples.
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.
@@ -49,7 +48,6 @@
       
       -- Removing variables with too many missing values --
       
-      i QC samples found. Excluding 2 QC samples from removal process.
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.
@@ -87,7 +85,6 @@
       
       -- Removing variables with too many missing values --
       
-      i No QC samples found. Using all samples.
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.
@@ -120,7 +117,6 @@
       
       -- Removing variables with too many missing values --
       
-      i No QC samples found. Using all samples.
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.
@@ -148,7 +144,6 @@
       
       -- Removing variables with too many missing values --
       
-      i QC samples found. Excluding 2 QC samples from removal process.
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -72,10 +72,14 @@
       i Batch column  not found in sample_info. Skipping batch correction.
       v Batch correction completed.
 
-# auto_clean works with NULL qc_name
+# auto_clean ignores deprecated qc_name
 
     Code
       result_exp <- auto_clean(test_exp, qc_name = NULL, standardize_variable = FALSE)
+    Condition
+      Warning:
+      The `qc_name` argument of `auto_clean()` is deprecated as of glyclean 0.14.0.
+      i This function no longer uses QC sample information and the `qc_name` parameter will be removed in a future release.
     Message
       
       -- Normalizing data --

--- a/tests/testthat/_snaps/auto-remove.md
+++ b/tests/testthat/_snaps/auto-remove.md
@@ -1,9 +1,8 @@
-# auto_remove works with simple preset
+# auto_remove includes QC samples in simple preset filtering
 
     Code
       res <- auto_remove(exp, preset = "simple", group_col = "group", qc_name = "QC")
     Message
-      i QC samples found. Excluding 2 QC samples from removal process.
       i Applying preset "simple"...
       i Total removed: 1 (10%) variables.
 
@@ -11,8 +10,11 @@
 
     Code
       res <- auto_remove(exp, preset = "simple", group_col = "group", qc_name = NULL)
+    Condition
+      Warning:
+      The `qc_name` argument of `auto_remove()` is deprecated as of glyclean 0.14.0.
+      i This function no longer uses QC sample information and the `qc_name` parameter will be removed in a future release.
     Message
-      i No QC samples found. Using all samples.
       i Applying preset "simple"...
       i Total removed: 1 (10%) variables.
 
@@ -21,7 +23,6 @@
     Code
       res <- auto_remove(exp, preset = "discovery", group_col = "group", qc_name = "QC")
     Message
-      i QC samples found. Excluding 2 QC samples from removal process.
       i Applying preset "discovery"...
       i Total removed: 2 (20%) variables.
 
@@ -30,7 +31,6 @@
     Code
       res <- auto_remove(exp, preset = "biomarker", group_col = "group", qc_name = "QC")
     Message
-      i QC samples found. Excluding 2 QC samples from removal process.
       i Applying preset "biomarker"...
       i Total removed: 2 (20%) variables.
 
@@ -39,7 +39,6 @@
     Code
       res <- auto_remove(exp, preset = "simple", group_col = "group", qc_name = "QC")
     Message
-      i No QC samples found. Using all samples.
       i Applying preset "simple"...
       i Total removed: 1 (10%) variables.
 

--- a/tests/testthat/test-auto-clean.R
+++ b/tests/testthat/test-auto-clean.R
@@ -44,7 +44,7 @@ test_that("auto_clean works for glycoproteomics data with QC", {
   expect_false(any(is.na(result_exp$expr_mat)))
 })
 
-test_that("auto_clean works with NULL qc_name", {
+test_that("auto_clean ignores deprecated qc_name", {
   set.seed(123)
   test_exp <- complex_exp()
 

--- a/tests/testthat/test-auto-remove.R
+++ b/tests/testthat/test-auto-remove.R
@@ -1,6 +1,5 @@
-test_that("auto_remove works with simple preset", {
+test_that("auto_remove includes QC samples in simple preset filtering", {
   # Setup: 10 vars, 10 samples (4A, 4B, 2QC)
-  # QC samples should be ignored
   samples <- c(paste0("A", 1:4), paste0("B", 1:4), "QC1", "QC2")
   groups <- c(rep("A", 4), rep("B", 4), rep("QC", 2))
 
@@ -13,8 +12,10 @@ test_that("auto_remove works with simple preset", {
 
   exp <- glyexp::experiment(expr_mat, sample_info, var_info)
 
-  # V1: 60% missing in non-QC (5/8 samples: A1-A4, B1)
+  # V1: 50% missing across all samples, so it should be kept.
   exp$expr_mat["V1", c("A1", "A2", "A3", "A4", "B1")] <- NA
+  # V2: 60% missing across all samples because QC samples are included.
+  exp$expr_mat["V2", c("A1", "A2", "A3", "A4", "QC1", "QC2")] <- NA
 
   # Run auto_remove
   expect_snapshot(
@@ -26,7 +27,8 @@ test_that("auto_remove works with simple preset", {
     )
   )
 
-  expect_false("V1" %in% rownames(res$expr_mat))
+  expect_true("V1" %in% rownames(res$expr_mat))
+  expect_false("V2" %in% rownames(res$expr_mat))
   expect_equal(nrow(res$expr_mat), 9)
 })
 
@@ -72,16 +74,18 @@ test_that("auto_remove works with discovery preset", {
 
   exp <- glyexp::experiment(expr_mat, sample_info, var_info)
 
-  # V1: 90% missing in non-QC (should be removed by global > 80%)
-  exp$expr_mat["V1", c("A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4")] <- NA
+  # V1: 90% missing across all samples (should be removed by global > 80%)
+  exp$expr_mat["V1", c("A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4", "QC1")] <- NA
 
-  # V2: 60% missing in non-QC. Group A: 100% (>50%), Group B: 25% (<50%).
+  # V2: 50% missing across all samples. Group A: 100% (>50%),
+  # Group B: 25% (<50%), QC: 0% (<50%).
   # Should be KEPT (strict=FALSE)
   exp$expr_mat["V2", c("A1", "A2", "A3", "A4", "B1")] <- NA
 
-  # V3: 60% missing in non-QC. Group A: 75% (>50%), Group B: 75% (>50%).
+  # V3: 80% missing across all samples. Group A: 75% (>50%),
+  # Group B: 75% (>50%), QC: 100% (>50%).
   # Should be REMOVED
-  exp$expr_mat["V3", c("A1", "A2", "A3", "B1", "B2", "B3")] <- NA
+  exp$expr_mat["V3", c("A1", "A2", "A3", "B1", "B2", "B3", "QC1", "QC2")] <- NA
 
   expect_snapshot(
     res <- auto_remove(

--- a/tests/testthat/test-inspect.R
+++ b/tests/testthat/test-inspect.R
@@ -1,10 +1,13 @@
-test_that("inspect_experiment handles NULL qc_name", {
+test_that("inspect_experiment reports group availability only", {
   exp <- simple_exp(3, 4)
   exp$sample_info$group <- c("A", "QC", "B", "QC")
 
-  info <- inspect_experiment(exp, group_col = "group", qc_name = NULL)
+  info <- inspect_experiment(exp, group_col = "group")
 
   expect_true(info$has_group)
-  expect_false(info$has_qc)
-  expect_null(info$qc_samples)
+  expect_named(info, "has_group")
+
+  info <- inspect_experiment(exp, group_col = NULL)
+  expect_false(info$has_group)
+  expect_named(info, "has_group")
 })


### PR DESCRIPTION
## Summary
- Deprecate `qc_name` in `auto_clean()` and make it a no-op argument with a lifecycle warning.
- Remove QC-specific inspection from `inspect_experiment()` so it now reports only group availability.
- Update the `auto_remove()` call path, documentation, and tests to match the simplified contract.

## Testing
- Added and updated unit tests for `auto_clean()`, `auto_remove()`, and `inspect_experiment()`.
- Regenerated documentation and snapshot files.
- Full package test suite passed locally with one existing skipped test.