### PR TITLE
Split auto helper selection messages into method and reason lines

### DIFF
--- a/R/auto-impute.R
+++ b/R/auto-impute.R
@@ -71,7 +71,10 @@ auto_impute <- function(
   strategy <- .choose_auto_impute_strategy(n_samples, exp_type)
 
   cli::cli_alert_info(
-    "Using default imputation method for {.val {strategy$exp_type}} with {strategy$sample_group}: {.fn {strategy$method_name}}."
+    "Imputation method: {.fn {strategy$method_name}}"
+  )
+  cli::cli_alert_info(
+    "Reason: default for {.val {strategy$exp_type}} with {strategy$sample_group}."
   )
 
   switch(

--- a/R/auto-normalize.R
+++ b/R/auto-normalize.R
@@ -64,7 +64,10 @@ auto_normalize <- function(
   strategy <- .choose_auto_normalize_strategy(glyexp::get_exp_type(exp))
 
   cli::cli_alert_info(
-    "Using default normalization method for {.val {strategy$exp_type}}: {.fn {strategy$method_name}}."
+    "Normalization method: {.fn {strategy$method_name}}"
+  )
+  cli::cli_alert_info(
+    "Reason: default for {.val {strategy$exp_type}}."
   )
 
   switch(

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -6,7 +6,8 @@
       
       -- Normalizing data --
       
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
       v Normalization completed.
       
       -- Removing variables with too many missing values --
@@ -17,7 +18,8 @@
       
       -- Imputing missing values --
       
-      i Using default imputation method for "glycoproteomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with n_samples < 30.
       v Imputation completed.
       
       -- Aggregating data --
@@ -27,7 +29,8 @@
       
       -- Normalizing data again --
       
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -43,7 +46,8 @@
       
       -- Normalizing data --
       
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
       v Normalization completed.
       
       -- Removing variables with too many missing values --
@@ -54,7 +58,8 @@
       
       -- Imputing missing values --
       
-      i Using default imputation method for "glycoproteomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with n_samples < 30.
       v Imputation completed.
       
       -- Aggregating data --
@@ -64,7 +69,8 @@
       
       -- Normalizing data again --
       
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -84,7 +90,8 @@
       
       -- Normalizing data --
       
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
       v Normalization completed.
       
       -- Removing variables with too many missing values --
@@ -95,7 +102,8 @@
       
       -- Imputing missing values --
       
-      i Using default imputation method for "glycoproteomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with n_samples < 30.
       v Imputation completed.
       
       -- Aggregating data --
@@ -105,7 +113,8 @@
       
       -- Normalizing data again --
       
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -127,12 +136,14 @@
       
       -- Imputing missing values --
       
-      i Using default imputation method for "glycomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycomics" with n_samples < 30.
       v Imputation completed.
       
       -- Normalizing data --
       
-      i Using default normalization method for "glycomics": `normalize_total_area()`.
+      i Normalization method: `normalize_total_area()`
+      i Reason: default for "glycomics".
       v Normalization completed.
       
       -- Correcting batch effects --
@@ -154,12 +165,14 @@
       
       -- Imputing missing values --
       
-      i Using default imputation method for "glycomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycomics" with n_samples < 30.
       v Imputation completed.
       
       -- Normalizing data --
       
-      i Using default normalization method for "glycomics": `normalize_total_area()`.
+      i Normalization method: `normalize_total_area()`
+      i Reason: default for "glycomics".
       v Normalization completed.
       
       -- Correcting batch effects --

--- a/tests/testthat/_snaps/auto-impute.md
+++ b/tests/testthat/_snaps/auto-impute.md
@@ -8,7 +8,8 @@
       The `to_try` argument of `auto_impute()` is deprecated as of glyclean 0.14.0.
       i The automatic imputation strategy is now deterministic and does not require user-specified methods to try. The `to_try` parameter will be removed in a future release.
     Message
-      i Using default imputation method for "glycoproteomics" with 30 <= n_samples <= 100: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with 30 <= n_samples <= 100.
 
 # auto_impute handles NULL qc_name
 
@@ -19,7 +20,8 @@
       The `qc_name` argument of `auto_impute()` is deprecated as of glyclean 0.14.0.
       i This function no longer uses QC sample information and the `qc_name` parameter will be removed in a future release.
     Message
-      i Using default imputation method for "glycomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycomics" with n_samples < 30.
 
 # auto_impute rejects unsupported experiment types
 
@@ -44,14 +46,16 @@
     Code
       result <- auto_impute(exp, group_col = NULL)
     Message
-      i Using default imputation method for "glycoproteomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with n_samples < 30.
 
 # auto_impute handles non-existent group_col gracefully
 
     Code
       result <- auto_impute(exp, group_col = "nonexistent")
     Message
-      i Using default imputation method for "glycoproteomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with n_samples < 30.
 
 # auto_impute validates input and ignores deprecated arguments
 
@@ -65,5 +69,6 @@
       The `to_try` argument of `auto_impute()` is deprecated as of glyclean 0.14.0.
       i The automatic imputation strategy is now deterministic and does not require user-specified methods to try. The `to_try` parameter will be removed in a future release.
     Message
-      i Using default imputation method for "glycoproteomics" with n_samples < 30: `impute_min_prob()`.
+      i Imputation method: `impute_min_prob()`
+      i Reason: default for "glycoproteomics" with n_samples < 30.
 

--- a/tests/testthat/_snaps/auto-normalize.md
+++ b/tests/testthat/_snaps/auto-normalize.md
@@ -8,7 +8,8 @@
       The `to_try` argument of `auto_normalize()` is deprecated as of glyclean 0.14.0.
       i The automatic normalization strategy is now deterministic and does not require user-specified methods to try. The `to_try` parameter will be removed in a future release.
     Message
-      i Using default normalization method for "glycomics": `normalize_total_area()`.
+      i Normalization method: `normalize_total_area()`
+      i Reason: default for "glycomics".
 
 # auto_normalize handles NULL qc_name
 
@@ -19,19 +20,22 @@
       The `qc_name` argument of `auto_normalize()` is deprecated as of glyclean 0.14.0.
       i This function no longer uses the `qc_name` parameter and it will be removed in a future release.
     Message
-      i Using default normalization method for "others": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "others".
 
 # auto_normalize works for glycoproteomics without QC
 
     Code
       auto <- auto_normalize(exp, group_col = NULL)
     Message
-      i Using default normalization method for "glycoproteomics": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
 
 # auto_normalize falls back to median for others
 
     Code
       auto <- auto_normalize(exp, group_col = NULL)
     Message
-      i Using default normalization method for "others": `normalize_median()`.
+      i Normalization method: `normalize_median()`
+      i Reason: default for "others".
 

--- a/tests/testthat/test-auto-impute.R
+++ b/tests/testthat/test-auto-impute.R
@@ -104,7 +104,7 @@ test_that("auto_impute uses min_prob for others experiments", {
 
   expect_message(
     result <- auto_impute(exp, group_col = NULL),
-    'for "others" with n_samples = 10: `impute_min_prob\\(\\)`'
+    'Reason: default for "others" with n_samples = 10\\.'
   )
   expect_equal(called, "impute_min_prob")
   expect_s3_class(result, "glyexp_experiment")


### PR DESCRIPTION
## Summary
- Updated `auto_normalize()` and `auto_impute()` to emit two separate info lines: one for the selected method and one for the reason it was chosen.
- Refreshed the affected snapshot tests for `auto-normalize`, `auto-impute`, and nested `auto-clean` output.
- Adjusted the `auto_impute()` message expectation in the unit test that checks the `others` fallback path.

## Testing
- `devtools::document()`
- `devtools::test(filter = "auto-normalize")`
- `devtools::test(filter = "auto-impute")`
- `devtools::test(filter = "auto-clean")`
- `devtools::test()`