### PR TITLE
[codex] fix auto_clean runtime dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,11 +24,7 @@ Suggests:
     glyrepr (>= 0.7.4),
     vsn,
     impute,
-    imputeLCMD,
-    pcaMethods,
     MASS,
-    missForest,
-    sva,
     knitr,
     rmarkdown,
     pheatmap,
@@ -46,9 +42,12 @@ Imports:
     cli,
     dplyr,
     glyexp (>= 0.12.1),
+    imputeLCMD,
     limma,
     magrittr,
     matrixStats,
+    missForest,
+    pcaMethods,
     purrr,
     rlang,
     seqinr,
@@ -61,7 +60,8 @@ Imports:
     forcats,
     stats,
     ggplot2,
-    lifecycle
+    lifecycle,
+    sva
 Depends: 
     R (>= 4.1)
 VignetteBuilder: knitr


### PR DESCRIPTION
## Summary

`auto_clean()` is the central entry point for glyclean and is probably the function most users call first, if not every user. It should run without extra dependency friction once glyclean is installed.

This PR moves the packages needed by the automatic pipeline from `Suggests` to `Imports`:

- `imputeLCMD`, `pcaMethods`, and `missForest` for methods selected by `auto_impute()`
- `sva` for ComBat batch correction through `auto_correct_batch_effect()`

Optional packages used for manual methods, plotting, tests, and vignettes stay in `Suggests`.

## Why this matters

Before this change, a user could install glyclean, call `auto_clean()`, and still hit missing-package errors from dependencies that the automatic path may choose internally. Since `auto_clean()` is the main out-of-box workflow, those dependencies should be installed with the package rather than discovered by users at runtime.

## Validation

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "auto")'`
- `Rscript -e 'devtools::test()'`
- `git diff --check`