### PR TITLE
Reimplement impute_min_prob without imputeLCMD

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Imports:
     cli,
     dplyr,
     glyexp (>= 0.12.1),
-    imputeLCMD,
     limma,
     magrittr,
     matrixStats,

--- a/R/impute.R
+++ b/R/impute.R
@@ -337,39 +337,59 @@ impute_svd.default <- function(x, by = NULL, ...) {
 
 #' Minimum Probability Imputation
 #'
-#' A wrapper around the [imputeLCMD::impute.MinProb()].
 #' Impute missing values using random draws from the left-censored
-#' gaussian distribution.
+#' gaussian distribution. Missing values are imputed on the log2 intensity
+#' scale and then transformed back to the original scale.
 #'
 #' @param x Either a `glyexp_experiment` object or a matrix.
 #'   If a matrix, rows should be variables and columns should be samples.
 #' @param by Either a column name in `sample_info` (string) or a factor/vector
 #'   specifying group assignments for each sample. Used for grouping when imputing missing values.
-#' @param ... Additional arguments to pass to `imputeLCMD::impute.MinProb()`.
+#' @param q Quantile used to estimate the lower-intensity center for each
+#'   sample. Default is `0.01`.
+#' @param tune.sigma Non-negative multiplier for the standard deviation of the
+#'   left-censored draw distribution. Default is `1`.
 #'
 #' @return Returns the same type as the input. If `x` is a `glyexp_experiment`,
 #'   returns a `glyexp_experiment` with missing values imputed.
 #'   If `x` is a matrix, returns a matrix with missing values imputed.
 #' @export
-impute_min_prob <- function(x, by = NULL, ...) {
+impute_min_prob <- function(x, by = NULL, q = 0.01, tune.sigma = 1) {
   UseMethod("impute_min_prob")
 }
 
 #' @rdname impute_min_prob
 #' @export
-impute_min_prob.glyexp_experiment <- function(x, by = NULL, ...) {
-  .dispatch_and_apply_by_group(x, .impute_min_prob, by = by, ...)
+impute_min_prob.glyexp_experiment <- function(
+  x,
+  by = NULL,
+  q = 0.01,
+  tune.sigma = 1
+) {
+  .dispatch_and_apply_by_group(
+    x,
+    .impute_min_prob,
+    by = by,
+    q = q,
+    tune.sigma = tune.sigma
+  )
 }
 
 #' @rdname impute_min_prob
 #' @export
-impute_min_prob.matrix <- function(x, by = NULL, ...) {
-  .dispatch_and_apply_by_group(x, .impute_min_prob, by = by, ...)
+impute_min_prob.matrix <- function(x, by = NULL, q = 0.01, tune.sigma = 1) {
+  .dispatch_and_apply_by_group(
+    x,
+    .impute_min_prob,
+    by = by,
+    q = q,
+    tune.sigma = tune.sigma
+  )
 }
 
 #' @rdname impute_min_prob
 #' @export
-impute_min_prob.default <- function(x, by = NULL, ...) {
+impute_min_prob.default <- function(x, by = NULL, q = 0.01, tune.sigma = 1) {
   cli::cli_abort(c(
     "{.arg x} must be a {.cls glyexp_experiment} object or a {.cls matrix}.",
     "x" = "Got {.cls {class(x)}}."
@@ -504,15 +524,67 @@ impute_miss_forest.default <- function(x, by = NULL, seed = 123, ...) {
 }
 
 
-.impute_min_prob <- function(mat, ...) {
-  rlang::check_installed("imputeLCMD", reason = "to use `impute_min_prob()`")
+.impute_min_prob <- function(mat, q = 0.01, tune.sigma = 1) {
+  checkmate::assert_number(q, lower = 0, upper = 1, finite = TRUE)
+  checkmate::assert_number(tune.sigma, lower = 0, finite = TRUE)
+
+  if (!anyNA(mat)) {
+    return(mat)
+  }
+
   normed <- log2(mat)
-  # Use withr::with_output_sink to silence the output from imputeLCMD::impute.MinProb
-  normed <- withr::with_output_sink(
-    tempfile(),
-    imputeLCMD::impute.MinProb(normed, ...)
+  sample_centers <- .min_prob_sample_centers(normed, q)
+  draw_sd <- .min_prob_draw_sd(normed, tune.sigma)
+
+  imputed_cols <- purrr::map(seq_len(ncol(normed)), function(sample_idx) {
+    sample_values <- normed[, sample_idx]
+    missing_idx <- which(is.na(sample_values))
+
+    if (length(missing_idx) > 0) {
+      sample_draws <- stats::rnorm(
+        nrow(normed),
+        mean = sample_centers[sample_idx],
+        sd = draw_sd
+      )
+      sample_values[missing_idx] <- sample_draws[missing_idx]
+    }
+
+    sample_values
+  })
+
+  imputed <- do.call(cbind, imputed_cols)
+  dimnames(imputed) <- dimnames(mat)
+  2^imputed
+}
+
+
+.min_prob_sample_centers <- function(normed, q) {
+  purrr::map_dbl(
+    seq_len(ncol(normed)),
+    ~ unname(stats::quantile(normed[, .x], probs = q, na.rm = TRUE))
   )
-  2^normed
+}
+
+
+.min_prob_draw_sd <- function(normed, tune.sigma) {
+  observed_fraction <- rowMeans(!is.na(normed))
+  filtered <- normed[observed_fraction > 0.5, , drop = FALSE]
+  feature_sds <- purrr::map_dbl(
+    seq_len(nrow(filtered)),
+    ~ stats::sd(filtered[.x, ], na.rm = TRUE)
+  )
+  draw_sd <- stats::median(feature_sds, na.rm = TRUE) * tune.sigma
+
+  if (is.finite(draw_sd)) {
+    return(draw_sd)
+  }
+
+  fallback_sd <- stats::sd(as.numeric(normed), na.rm = TRUE) * tune.sigma
+  if (is.finite(fallback_sd)) {
+    return(fallback_sd)
+  }
+
+  0
 }
 
 

--- a/R/impute.R
+++ b/R/impute.R
@@ -349,12 +349,14 @@ impute_svd.default <- function(x, by = NULL, ...) {
 #'   sample. Default is `0.01`.
 #' @param tune.sigma Non-negative multiplier for the standard deviation of the
 #'   left-censored draw distribution. Default is `1`.
+#' @param ... Reserved for backward compatibility. Extra arguments are not
+#'   supported.
 #'
 #' @return Returns the same type as the input. If `x` is a `glyexp_experiment`,
 #'   returns a `glyexp_experiment` with missing values imputed.
 #'   If `x` is a matrix, returns a matrix with missing values imputed.
 #' @export
-impute_min_prob <- function(x, by = NULL, q = 0.01, tune.sigma = 1) {
+impute_min_prob <- function(x, by = NULL, q = 0.01, tune.sigma = 1, ...) {
   UseMethod("impute_min_prob")
 }
 
@@ -364,32 +366,47 @@ impute_min_prob.glyexp_experiment <- function(
   x,
   by = NULL,
   q = 0.01,
-  tune.sigma = 1
+  tune.sigma = 1,
+  ...
 ) {
   .dispatch_and_apply_by_group(
     x,
     .impute_min_prob,
     by = by,
     q = q,
-    tune.sigma = tune.sigma
+    tune.sigma = tune.sigma,
+    ...
   )
 }
 
 #' @rdname impute_min_prob
 #' @export
-impute_min_prob.matrix <- function(x, by = NULL, q = 0.01, tune.sigma = 1) {
+impute_min_prob.matrix <- function(
+  x,
+  by = NULL,
+  q = 0.01,
+  tune.sigma = 1,
+  ...
+) {
   .dispatch_and_apply_by_group(
     x,
     .impute_min_prob,
     by = by,
     q = q,
-    tune.sigma = tune.sigma
+    tune.sigma = tune.sigma,
+    ...
   )
 }
 
 #' @rdname impute_min_prob
 #' @export
-impute_min_prob.default <- function(x, by = NULL, q = 0.01, tune.sigma = 1) {
+impute_min_prob.default <- function(
+  x,
+  by = NULL,
+  q = 0.01,
+  tune.sigma = 1,
+  ...
+) {
   cli::cli_abort(c(
     "{.arg x} must be a {.cls glyexp_experiment} object or a {.cls matrix}.",
     "x" = "Got {.cls {class(x)}}."
@@ -524,7 +541,8 @@ impute_miss_forest.default <- function(x, by = NULL, seed = 123, ...) {
 }
 
 
-.impute_min_prob <- function(mat, q = 0.01, tune.sigma = 1) {
+.impute_min_prob <- function(mat, q = 0.01, tune.sigma = 1, ...) {
+  .check_impute_min_prob_dots(...)
   checkmate::assert_number(q, lower = 0, upper = 1, finite = TRUE)
   checkmate::assert_number(tune.sigma, lower = 0, finite = TRUE)
 
@@ -558,14 +576,62 @@ impute_miss_forest.default <- function(x, by = NULL, seed = 123, ...) {
 }
 
 
-.min_prob_sample_centers <- function(normed, q) {
-  purrr::map_dbl(
-    seq_len(ncol(normed)),
-    ~ unname(stats::quantile(normed[, .x], probs = q, na.rm = TRUE))
-  )
+#' Check unsupported MinProb compatibility arguments
+#'
+#' @param ... Arguments reserved for backward compatibility.
+#'
+#' @return Invisibly returns `NULL`.
+#' @noRd
+.check_impute_min_prob_dots <- function(...) {
+  dots <- rlang::list2(...)
+
+  if (length(dots) == 0) {
+    return(invisible(NULL))
+  }
+
+  cli::cli_abort(c(
+    "Unsupported argument passed to {.fn impute_min_prob}.",
+    "i" = "Use {.arg q} and {.arg tune.sigma} directly; other arguments are not supported."
+  ))
 }
 
 
+#' Estimate MinProb sample centers
+#'
+#' @param normed A log2-transformed intensity matrix.
+#' @param q Quantile used to estimate the lower-intensity center.
+#'
+#' @return A numeric vector with one center per sample.
+#' @noRd
+.min_prob_sample_centers <- function(normed, q) {
+  observed_values <- as.numeric(normed[!is.na(normed)])
+  if (length(observed_values) == 0) {
+    cli::cli_abort(
+      "{.arg x} must contain at least one observed value for {.fn impute_min_prob}."
+    )
+  }
+
+  global_center <- unname(stats::quantile(
+    observed_values,
+    probs = q,
+    na.rm = TRUE
+  ))
+  centers <- purrr::map_dbl(
+    seq_len(ncol(normed)),
+    ~ unname(stats::quantile(normed[, .x], probs = q, na.rm = TRUE))
+  )
+  centers[is.na(centers)] <- global_center
+  centers
+}
+
+
+#' Estimate MinProb draw standard deviation
+#'
+#' @param normed A log2-transformed intensity matrix.
+#' @param tune.sigma Multiplier for the left-censored draw standard deviation.
+#'
+#' @return A scalar standard deviation for random draws.
+#' @noRd
 .min_prob_draw_sd <- function(normed, tune.sigma) {
   observed_fraction <- rowMeans(!is.na(normed))
   filtered <- normed[observed_fraction > 0.5, , drop = FALSE]

--- a/man/impute_min_prob.Rd
+++ b/man/impute_min_prob.Rd
@@ -7,13 +7,13 @@
 \alias{impute_min_prob.default}
 \title{Minimum Probability Imputation}
 \usage{
-impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1)
+impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1, ...)
 
-\method{impute_min_prob}{glyexp_experiment}(x, by = NULL, q = 0.01, tune.sigma = 1)
+\method{impute_min_prob}{glyexp_experiment}(x, by = NULL, q = 0.01, tune.sigma = 1, ...)
 
-\method{impute_min_prob}{matrix}(x, by = NULL, q = 0.01, tune.sigma = 1)
+\method{impute_min_prob}{matrix}(x, by = NULL, q = 0.01, tune.sigma = 1, ...)
 
-\method{impute_min_prob}{default}(x, by = NULL, q = 0.01, tune.sigma = 1)
+\method{impute_min_prob}{default}(x, by = NULL, q = 0.01, tune.sigma = 1, ...)
 }
 \arguments{
 \item{x}{Either a \code{glyexp_experiment} object or a matrix.
@@ -27,6 +27,9 @@ sample. Default is \code{0.01}.}
 
 \item{tune.sigma}{Non-negative multiplier for the standard deviation of the
 left-censored draw distribution. Default is \code{1}.}
+
+\item{...}{Reserved for backward compatibility. Extra arguments are not
+supported.}
 }
 \value{
 Returns the same type as the input. If \code{x} is a \code{glyexp_experiment},

--- a/man/impute_min_prob.Rd
+++ b/man/impute_min_prob.Rd
@@ -7,13 +7,13 @@
 \alias{impute_min_prob.default}
 \title{Minimum Probability Imputation}
 \usage{
-impute_min_prob(x, by = NULL, ...)
+impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1)
 
-\method{impute_min_prob}{glyexp_experiment}(x, by = NULL, ...)
+\method{impute_min_prob}{glyexp_experiment}(x, by = NULL, q = 0.01, tune.sigma = 1)
 
-\method{impute_min_prob}{matrix}(x, by = NULL, ...)
+\method{impute_min_prob}{matrix}(x, by = NULL, q = 0.01, tune.sigma = 1)
 
-\method{impute_min_prob}{default}(x, by = NULL, ...)
+\method{impute_min_prob}{default}(x, by = NULL, q = 0.01, tune.sigma = 1)
 }
 \arguments{
 \item{x}{Either a \code{glyexp_experiment} object or a matrix.
@@ -22,7 +22,11 @@ If a matrix, rows should be variables and columns should be samples.}
 \item{by}{Either a column name in \code{sample_info} (string) or a factor/vector
 specifying group assignments for each sample. Used for grouping when imputing missing values.}
 
-\item{...}{Additional arguments to pass to \code{imputeLCMD::impute.MinProb()}.}
+\item{q}{Quantile used to estimate the lower-intensity center for each
+sample. Default is \code{0.01}.}
+
+\item{tune.sigma}{Non-negative multiplier for the standard deviation of the
+left-censored draw distribution. Default is \code{1}.}
 }
 \value{
 Returns the same type as the input. If \code{x} is a \code{glyexp_experiment},
@@ -30,7 +34,7 @@ returns a \code{glyexp_experiment} with missing values imputed.
 If \code{x} is a matrix, returns a matrix with missing values imputed.
 }
 \description{
-A wrapper around the \code{\link[imputeLCMD:impute.MinProb]{imputeLCMD::impute.MinProb()}}.
 Impute missing values using random draws from the left-censored
-gaussian distribution.
+gaussian distribution. Missing values are imputed on the log2 intensity
+scale and then transformed back to the original scale.
 }

--- a/tests/testthat/test-impute.R
+++ b/tests/testthat/test-impute.R
@@ -112,9 +112,61 @@ test_that("impute_svd works", {
 
 
 test_that("impute_min_prob works", {
-  skip_if_not_installed("imputeLCMD")
   result_exp <- impute_min_prob(test_exp)
   expect_equal(sum(is.na(result_exp$expr_mat)), 0)
+})
+
+test_that("impute_min_prob uses left-censored log-scale draws", {
+  test_mat <- matrix(
+    c(
+      2,
+      4,
+      8,
+      4,
+      NA,
+      16,
+      NA,
+      8,
+      32,
+      16,
+      32,
+      64
+    ),
+    nrow = 4,
+    byrow = TRUE
+  )
+  rownames(test_mat) <- paste0("V", 1:4)
+  colnames(test_mat) <- paste0("S", 1:3)
+
+  normed <- log2(test_mat)
+  sample_mins <- purrr::map_dbl(
+    seq_len(ncol(normed)),
+    ~ unname(stats::quantile(normed[, .x], probs = 0.1, na.rm = TRUE))
+  )
+  feature_sds <- purrr::map_dbl(
+    which(rowMeans(!is.na(normed)) > 0.5),
+    ~ stats::sd(normed[.x, ], na.rm = TRUE)
+  )
+  draw_sd <- stats::median(feature_sds, na.rm = TRUE) * 0.25
+
+  expected <- normed
+  set.seed(42)
+  purrr::walk(seq_len(ncol(normed)), function(sample_idx) {
+    sample_draws <- stats::rnorm(
+      nrow(normed),
+      mean = sample_mins[sample_idx],
+      sd = draw_sd
+    )
+    missing_idx <- which(is.na(normed[, sample_idx]))
+    expected[missing_idx, sample_idx] <<- sample_draws[missing_idx]
+  })
+
+  set.seed(42)
+  result <- impute_min_prob(test_mat, q = 0.1, tune.sigma = 0.25)
+
+  expect_equal(result, 2^expected)
+  expect_equal(result[!is.na(test_mat)], test_mat[!is.na(test_mat)])
+  expect_equal(dimnames(result), dimnames(test_mat))
 })
 
 
@@ -203,8 +255,6 @@ test_that("matrix input with by parameter: wrong length vector should error for 
 })
 
 test_that("impute_min_prob works with matrix input and by parameter", {
-  skip_if_not_installed("imputeLCMD")
-
   # Create test matrix with missing values
   test_mat <- matrix(rnorm(24, mean = 10, sd = 2), nrow = 4, ncol = 6)
   test_mat[c(1, 7, 13, 19)] <- NA # Add some missing values
@@ -265,6 +315,13 @@ test_that("impute functions error on unsupported input", {
   })
 })
 
+test_that("impute_min_prob is self-contained", {
+  deps <- packageDescription("glyclean")[c("Imports", "Suggests")]
+  deps <- paste(unlist(deps), collapse = "\n")
+
+  expect_false(grepl("imputeLCMD", deps, fixed = TRUE))
+})
+
 test_that("impute methods requiring suggested packages run or error cleanly", {
   test_mat <- matrix(runif(36, 1, 100), nrow = 6)
   test_mat[1, 2] <- NA
@@ -277,7 +334,6 @@ test_that("impute methods requiring suggested packages run or error cleanly", {
     list(fn = impute_bpca, pkg = "pcaMethods", args = list()),
     list(fn = impute_ppca, pkg = "pcaMethods", args = list()),
     list(fn = impute_svd, pkg = "pcaMethods", args = list()),
-    list(fn = impute_min_prob, pkg = "imputeLCMD", args = list()),
     list(fn = impute_miss_forest, pkg = "missForest", args = list(seed = 1))
   )
 

--- a/tests/testthat/test-impute.R
+++ b/tests/testthat/test-impute.R
@@ -169,6 +169,45 @@ test_that("impute_min_prob uses left-censored log-scale draws", {
   expect_equal(dimnames(result), dimnames(test_mat))
 })
 
+test_that("impute_min_prob falls back to global center for all-missing samples", {
+  test_mat <- matrix(
+    c(
+      2,
+      NA,
+      8,
+      4,
+      NA,
+      16,
+      8,
+      NA,
+      32,
+      16,
+      NA,
+      64
+    ),
+    nrow = 4,
+    byrow = TRUE
+  )
+  rownames(test_mat) <- paste0("V", 1:4)
+  colnames(test_mat) <- paste0("S", 1:3)
+
+  set.seed(42)
+  result <- impute_min_prob(test_mat, q = 0.1, tune.sigma = 0)
+
+  expect_equal(sum(is.na(result)), 0)
+  expect_equal(result[, c("S1", "S3")], test_mat[, c("S1", "S3")])
+  expect_true(all(is.finite(result[, "S2"])))
+})
+
+test_that("impute_min_prob validates unsupported dots clearly", {
+  test_mat <- matrix(c(1, NA, 3, 4), nrow = 2)
+
+  expect_error(
+    impute_min_prob(test_mat, unsupported = TRUE),
+    "Unsupported argument"
+  )
+})
+
 
 test_that("impute_miss_forest works", {
   skip_if_not_installed("missForest")


### PR DESCRIPTION
## Summary
- Replaced `impute_min_prob()` with an internal MinProb implementation that samples on the log2 scale and back-transforms to the original scale.
- Removed `imputeLCMD` from `DESCRIPTION` and updated the generated help page to document the new `q` and `tune.sigma` arguments.
- Strengthened `tests/testthat/test-impute.R` to cover the self-contained behavior and removed the dependency-gated test path.

## Testing
- `devtools::document()`
- `air format .`
- `devtools::test(filter = "impute")`
- `devtools::test()`