### PR TITLE
perf: speed up aggregate()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 * Non-automatic preprocessing and QC functions now accept plain `SummarizedExperiment` objects and preserve their class.
 * All preprocessing and QC functions now natively accept `glyexp::GlycomicSE` and `glyexp::GlycoproteomicSE`, preserve the input subclass, and continue to support `glyexp::experiment()` objects. (#19)
 
+## Minor improvements and bug fixes
+
+* `aggregate()` now processes large glycoproteomics experiments substantially faster while preserving group order and metadata. (#21)
+
 # glyclean 0.14.1
 
 ## Minor improvements and bug fixes

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -255,8 +255,12 @@ glyclean_aggregate.default <- function(
   group_col <- make.unique(c(colnames(var_info), ".aggregate_group"))[[
     ncol(var_info) + 1L
   ]]
-  distinct_counts <- var_info |>
-    dplyr::mutate(!!group_col := .env$group_id) |>
+  distinct_data <- dplyr::select(
+    var_info,
+    tidyselect::all_of(descriptive_cols)
+  )
+  distinct_data[[group_col]] <- group_id
+  distinct_counts <- distinct_data |>
     dplyr::summarise(
       dplyr::across(tidyselect::all_of(descriptive_cols), dplyr::n_distinct),
       .by = tidyselect::all_of(group_col)
@@ -265,7 +269,6 @@ glyclean_aggregate.default <- function(
     descriptive_cols,
     ~ all(distinct_counts[[.x]] == 1L)
   )
-  var_info |>
-    dplyr::filter(!duplicated(.env$group_id)) |>
+  var_info[!duplicated(group_id), , drop = FALSE] |>
     dplyr::select(tidyselect::all_of(c(aggr_cols, kept_cols)))
 }

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -178,30 +178,17 @@ glyclean_aggregate.GlycoproteomicSE <- function(
       call = error_call
     )
   }
-  sample_info_df <- .get_sample_info(exp)
-  tb <- tibble::as_tibble(.get_expr_mat(exp), rownames = "variable") |>
-    tidyr::pivot_longer(
-      cols = -dplyr::all_of("variable"),
-      names_to = "sample",
-      values_to = "value"
-    ) |>
-    dplyr::left_join(var_info, by = "variable")
-  new_tb <- dplyr::summarise(
-    tb,
-    value = sum(.data$value, na.rm = TRUE),
-    .by = tidyselect::all_of(c(var_info_cols, "sample")),
+  group_id <- .get_aggregation_group_id(var_info, var_info_cols)
+  var_info_df <- .get_aggr_var_info(var_info, var_info_cols, group_id) |>
+    dplyr::mutate(variable = paste0("V", dplyr::row_number()), .before = 1)
+  expr_mat <- rowsum(
+    .get_expr_mat(exp),
+    group = group_id,
+    reorder = FALSE,
+    na.rm = TRUE
   )
-  add_cols <- .get_aggr_var_info(var_info, var_info_cols)
-  var_info_df <- new_tb %>%
-    dplyr::distinct(dplyr::across(tidyselect::all_of(var_info_cols))) %>%
-    dplyr::mutate(variable = paste0("V", dplyr::row_number()), .before = 1) %>%
-    dplyr::left_join(add_cols, by = var_info_cols)
-  expr_mat <- new_tb %>%
-    dplyr::left_join(var_info_df, by = var_info_cols) %>%
-    dplyr::select(tidyselect::all_of(c("sample", "variable", "value"))) %>%
-    tidyr::pivot_wider(names_from = "sample", values_from = "value") %>%
-    tibble::column_to_rownames("variable") %>%
-    as.matrix()
+  rownames(expr_mat) <- var_info_df$variable
+  sample_info_df <- .get_sample_info(exp)
   expr_mat <- expr_mat[
     var_info_df$variable,
     sample_info_df$sample,
@@ -217,6 +204,24 @@ glyclean_aggregate.GlycoproteomicSE <- function(
   } else {
     new_exp
   }
+}
+
+#' Get aggregation group identifiers
+#'
+#' Create integer group identifiers in the order that combinations of
+#' aggregation columns first occur in the variable information.
+#'
+#' @param var_info A tibble with the variable information.
+#' @param aggr_cols Column names used for aggregation.
+#'
+#' @returns An integer vector with one group identifier per variable.
+#'
+#' @noRd
+.get_aggregation_group_id <- function(var_info, aggr_cols) {
+  group_id <- var_info |>
+    dplyr::group_by(dplyr::across(tidyselect::all_of(aggr_cols))) |>
+    dplyr::group_indices()
+  match(group_id, unique(group_id))
 }
 
 #' @rdname aggregate
@@ -239,21 +244,28 @@ glyclean_aggregate.default <- function(
 #'
 #' @param var_info A tibble with the variable information.
 #' @param aggr_cols Column names used for aggregation.
+#' @param group_id Integer aggregation group identifiers in first-occurrence
+#'   order.
 #'
 #' @returns A tibble with the distinct values of the descriptive columns.
 #'
 #' @noRd
-.get_aggr_var_info <- function(var_info, aggr_cols) {
-  cols <- var_info |>
-    dplyr::select(-dplyr::all_of("variable")) |>
+.get_aggr_var_info <- function(var_info, aggr_cols, group_id) {
+  descriptive_cols <- setdiff(colnames(var_info), c("variable", aggr_cols))
+  group_col <- make.unique(c(colnames(var_info), ".aggregate_group"))[[
+    ncol(var_info) + 1L
+  ]]
+  distinct_counts <- var_info |>
+    dplyr::mutate(!!group_col := .env$group_id) |>
     dplyr::summarise(
-      dplyr::across(dplyr::everything(), dplyr::n_distinct),
-      .by = dplyr::all_of(aggr_cols)
-    ) |>
-    dplyr::select(-dplyr::all_of(aggr_cols)) |>
-    dplyr::select(dplyr::where(~ all(.x == 1))) |>
-    colnames()
+      dplyr::across(tidyselect::all_of(descriptive_cols), dplyr::n_distinct),
+      .by = tidyselect::all_of(group_col)
+    )
+  kept_cols <- purrr::keep(
+    descriptive_cols,
+    ~ all(distinct_counts[[.x]] == 1L)
+  )
   var_info |>
-    dplyr::select(dplyr::all_of(c(aggr_cols, cols))) |>
-    dplyr::distinct()
+    dplyr::filter(!duplicated(.env$group_id)) |>
+    dplyr::select(tidyselect::all_of(c(aggr_cols, kept_cols)))
 }

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -23,6 +23,43 @@ test_that("aggregating to glycoforms works", {
   )
 })
 
+test_that("aggregation preserves group order, missing-value sums, and metadata", {
+  exp <- complex_exp()
+  input_mat <- SummarizedExperiment::assay(exp)
+  first_group <- c(1, 2, 4, 5, 6, 7)
+  input_mat[first_group, 1] <- NA_real_
+  input_mat[1, 2] <- NA_real_
+  SummarizedExperiment::assay(exp) <- input_mat
+
+  res <- aggregate(exp, to_level = "gf", standardize_variable = FALSE)
+  result_mat <- SummarizedExperiment::assay(res)
+  result_var_info <- SummarizedExperiment::rowData(res)
+  expected_mat <- rbind(
+    colSums(input_mat[first_group, , drop = FALSE], na.rm = TRUE),
+    input_mat[3, ],
+    input_mat[8, ]
+  )
+  rownames(expected_mat) <- paste0("V", seq_len(nrow(expected_mat)))
+
+  expect_equal(result_mat, expected_mat)
+  expect_equal(result_var_info$protein_site, c(24L, 25L, 24L))
+  expected_compositions <- SummarizedExperiment::rowData(
+    exp
+  )$glycan_composition[
+    c(1, 3, 8)
+  ]
+  expect_equal(
+    as.character(result_var_info$glycan_composition),
+    as.character(expected_compositions)
+  )
+  expect_true(
+    glyrepr::is_glycan_composition(result_var_info$glycan_composition)
+  )
+  expect_true("gene" %in% colnames(result_var_info))
+  expect_false("peptide" %in% colnames(result_var_info))
+  expect_false("charge" %in% colnames(result_var_info))
+})
+
 test_that("aggregating to glycopeptides (with structures) works", {
   exp <- real_exp()
   res <- aggregate(exp, to_level = "gps", standardize_variable = FALSE)


### PR DESCRIPTION
## Summary

Speed up `aggregate()` by aggregating the abundance matrix directly instead of expanding it into a long table.

## Details

- compute stable integer group identifiers from variable metadata
- aggregate assay rows with `rowsum()` while preserving first-occurrence group order
- reuse group identifiers when retaining many-to-one metadata columns
- preserve existing missing-value sums and glycan composition classes
- add regression coverage for ordering, missing values, and metadata retention
- reduce measured runtime from 1.67 s to 0.082 s for a 1,000 x 20 workload and from 8.53 s to 0.30 s for a 5,000 x 20 workload

## Verification

- `devtools::document()`
- `devtools::test(filter = "aggregate")`
- `devtools::test()`
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings, 1 environment-only NOTE because the sandbox could not verify the system clock
- `air format R/aggregate.R tests/testthat/test-aggregate.R`
- `git diff --check`