### PR TITLE
fix: remove sparse variables before normalization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 ## Minor improvements and bug fixes
 
 * `aggregate()` now processes large glycoproteomics experiments substantially faster while preserving group order and metadata. (#21)
+* `auto_clean()` now removes glycoproteomics variables with excessive missingness before the first normalization step. (#23)
 
 # glyclean 0.14.1
 

--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -13,8 +13,8 @@
 #' - [auto_correct_batch_effect()]
 #'
 #' For glycoproteomics data, this function calls these functions in sequence:
-#' - [auto_normalize()]
 #' - [auto_remove()]
+#' - [auto_normalize()]
 #' - [auto_impute()]
 #' - [auto_aggregate()]
 #' - [auto_normalize()]
@@ -96,12 +96,6 @@ auto_clean <- function(
 }
 
 .auto_clean_glycoproteomics <- function(exp, params) {
-  cli::cli_h2("Normalizing data")
-  exp <- auto_normalize(
-    exp,
-    group_col = params$group_col
-  )
-  cli::cli_alert_success("Normalization completed.")
   cli::cli_h2("Removing variables with too many missing values")
   exp <- auto_remove(
     exp,
@@ -109,21 +103,32 @@ auto_clean <- function(
     group_col = params$group_col
   )
   cli::cli_alert_success("Variable removal completed.")
+
+  cli::cli_h2("Normalizing data")
+  exp <- auto_normalize(
+    exp,
+    group_col = params$group_col
+  )
+  cli::cli_alert_success("Normalization completed.")
+
   cli::cli_h2("Imputing missing values")
   exp <- auto_impute(
     exp,
     params$group_col
   )
   cli::cli_alert_success("Imputation completed.")
+
   cli::cli_h2("Aggregating data")
   exp <- auto_aggregate(exp, standardize_variable = params$standardize_variable)
   cli::cli_alert_success("Aggregation completed.")
+
   cli::cli_h2("Normalizing data again")
   exp <- auto_normalize(
     exp,
     group_col = params$group_col
   )
   cli::cli_alert_success("Normalization completed.")
+
   cli::cli_h2("Correcting batch effects")
   exp <- auto_correct_batch_effect(
     exp,
@@ -145,18 +150,21 @@ auto_clean <- function(
     group_col = params$group_col
   )
   cli::cli_alert_success("Variable removal completed.")
+
   cli::cli_h2("Imputing missing values")
   exp <- auto_impute(
     exp,
     params$group_col
   )
   cli::cli_alert_success("Imputation completed.")
+
   cli::cli_h2("Normalizing data")
   exp <- auto_normalize(
     exp,
     group_col = params$group_col
   )
   cli::cli_alert_success("Normalization completed.")
+
   cli::cli_h2("Correcting batch effects")
   exp <- auto_correct_batch_effect(
     exp,

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -69,8 +69,8 @@ For glycomics data, this function calls these functions in sequence:
 
 For glycoproteomics data, this function calls these functions in sequence:
 \itemize{
-\item \code{\link[=auto_normalize]{auto_normalize()}}
 \item \code{\link[=auto_remove]{auto_remove()}}
+\item \code{\link[=auto_normalize]{auto_normalize()}}
 \item \code{\link[=auto_impute]{auto_impute()}}
 \item \code{\link[=auto_aggregate]{auto_aggregate()}}
 \item \code{\link[=auto_normalize]{auto_normalize()}}

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -4,17 +4,17 @@
       result_exp <- auto_clean(test_exp, standardize_variable = FALSE)
     Message
       
-      -- Normalizing data --
-      
-      i Normalization method: `normalize_median()`
-      i Reason: default for "glycoproteomics".
-      v Normalization completed.
-      
       -- Removing variables with too many missing values --
       
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.
+      
+      -- Normalizing data --
+      
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
+      v Normalization completed.
       
       -- Imputing missing values --
       
@@ -44,17 +44,17 @@
       result_exp <- auto_clean(test_exp, standardize_variable = FALSE)
     Message
       
-      -- Normalizing data --
-      
-      i Normalization method: `normalize_median()`
-      i Reason: default for "glycoproteomics".
-      v Normalization completed.
-      
       -- Removing variables with too many missing values --
       
       i Applying preset "discovery"...
       i No variables removed.
       v Variable removal completed.
+      
+      -- Normalizing data --
+      
+      i Normalization method: `normalize_median()`
+      i Reason: default for "glycoproteomics".
+      v Normalization completed.
       
       -- Imputing missing values --
       


### PR DESCRIPTION
## Summary

Update the glycoproteomics `auto_clean()` pipeline to remove variables with excessive missingness before the first normalization step.

## Details

- Run `auto_remove()` before the initial `auto_normalize()` call for glycoproteomics experiments.
- Keep the remaining imputation, aggregation, second normalization, and batch-correction order unchanged.
- Synchronize the function documentation and test snapshots with the updated pipeline order.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "auto-clean")'` (17 passed)
- `Rscript -e 'devtools::test()'` (712 passed, 1 skipped)
- `Rscript -e 'devtools::check()'` (0 errors, 0 warnings, 1 environment-only system-clock note)
