### PR TITLE
feat: support plain SummarizedExperiment in automatic helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## New features
 
+* Automatic normalization, imputation, filtering, CoDA, and batch-correction helpers now accept plain `SummarizedExperiment` objects when the experiment type is `"others"`, while preserving the input class and metadata. (#24)
 * Non-automatic preprocessing and QC functions now accept plain `SummarizedExperiment` objects and preserve their class.
 * All preprocessing and QC functions now natively accept `glyexp::GlycomicSE` and `glyexp::GlycoproteomicSE`, preserve the input subclass, and continue to support `glyexp::experiment()` objects. (#19)
 

--- a/R/auto-coda.R
+++ b/R/auto-coda.R
@@ -7,15 +7,15 @@
 #' @inheritParams transform_clr
 #' @inheritSection transform_clr Algorithmic details
 #' @inheritSection transform_clr Motif quantification
-#' @param x A [glyexp::experiment()] object. [glyexp::GlycomicSE()] and
-#'   [glyexp::GlycoproteomicSE()] objects are also supported.
+#' @param x A [glyexp::experiment()] or
+#'   [SummarizedExperiment::SummarizedExperiment()] object.
 #'
-#' @returns A [glyexp::experiment()] object with a CoDA-transformed expression
-#'   matrix (ALR if >50 variables, CLR otherwise). Glyco SE inputs return the
-#'   same subclass.
+#' @returns The input container with a CoDA-transformed expression matrix (ALR
+#'   if >50 variables, CLR otherwise). SummarizedExperiment inputs return the
+#'   same class.
 #' @export
 auto_coda <- function(x, by = NULL, gamma = 0.1, group_scales = NULL) {
-  .assert_auto_container(x)
+  .assert_glyclean_container(x)
 
   if (nrow(x) > 50) {
     cli::cli_alert_info(

--- a/R/auto-correct-batch-effect.R
+++ b/R/auto-correct-batch-effect.R
@@ -11,8 +11,8 @@
 #' If no batch information is available,
 #' the function will return the original experiment.
 #'
-#' @param exp A [glyexp::experiment()] object. [glyexp::GlycomicSE()] and
-#'   [glyexp::GlycoproteomicSE()] objects are also supported.
+#' @param exp A [glyexp::experiment()] or
+#'   [SummarizedExperiment::SummarizedExperiment()] object.
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
 #' @param batch_col The column name in sample_info for batches. Default is "batch".
@@ -24,8 +24,8 @@
 #' @param confounding_threshold The threshold for Cramer's V to consider batch and group variables highly confounded.
 #'   Only used when `check_confounding` is TRUE. Default to 0.4.
 #'
-#' @return A [glyexp::experiment()] object with batch effects corrected. Glyco
-#'   SE inputs return the same subclass.
+#' @return The input container with batch effects corrected.
+#'   SummarizedExperiment inputs return the same class.
 #'
 #' @examples
 #' exp <- glyexp::real_experiment
@@ -40,7 +40,7 @@ auto_correct_batch_effect <- function(
   check_confounding = TRUE,
   confounding_threshold = 0.4
 ) {
-  .assert_auto_container(exp)
+  .assert_glyclean_container(exp)
   checkmate::assert_number(prop_threshold, lower = 0, upper = 1)
 
   sample_info <- .get_sample_info(exp)

--- a/R/auto-impute.R
+++ b/R/auto-impute.R
@@ -17,13 +17,13 @@
 #' fallback. [impute_sample_min()] and [impute_half_sample_min()] remain
 #' available for manual use, but they are not selected automatically.
 #'
-#' @param exp A [glyexp::experiment()] object. [glyexp::GlycomicSE()] and
-#'   [glyexp::GlycoproteomicSE()] objects are also supported.
+#' @param exp A [glyexp::experiment()] or
+#'   [SummarizedExperiment::SummarizedExperiment()] object.
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
 #'
-#' @returns The imputed [glyexp::experiment()] object. Glyco SE inputs return the
-#'   same subclass.
+#' @returns The imputed input container. SummarizedExperiment inputs return the
+#'   same class.
 #' @examples
 #' library(glyexp)
 #' exp_imputed <- auto_impute(real_experiment)
@@ -33,7 +33,7 @@ auto_impute <- function(
   group_col = "group"
 ) {
   # Check arguments
-  .assert_auto_container(exp)
+  .assert_glyclean_container(exp)
   checkmate::assert_string(group_col, null.ok = TRUE)
 
   .auto_impute_default(exp)

--- a/R/auto-normalize.R
+++ b/R/auto-normalize.R
@@ -10,13 +10,13 @@
 #' - `glycoproteomics`: [normalize_median()].
 #' - missing or other experiment types: [normalize_median()].
 #'
-#' @param exp A [glyexp::experiment()] object. [glyexp::GlycomicSE()] and
-#'   [glyexp::GlycoproteomicSE()] objects are also supported.
+#' @param exp A [glyexp::experiment()] or
+#'   [SummarizedExperiment::SummarizedExperiment()] object.
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
 #'
-#' @returns The normalized [glyexp::experiment()] object. Glyco SE inputs return
-#'   the same subclass.
+#' @returns The normalized input container. SummarizedExperiment inputs return
+#'   the same class.
 #' @examples
 #' library(glyexp)
 #' exp_normed <- auto_normalize(real_experiment)
@@ -26,7 +26,7 @@ auto_normalize <- function(
   group_col = "group"
 ) {
   # Check arguments
-  .assert_auto_container(exp)
+  .assert_glyclean_container(exp)
   checkmate::assert_string(group_col, null.ok = TRUE)
 
   .auto_normalize_default(exp)

--- a/R/auto-remove.R
+++ b/R/auto-remove.R
@@ -9,15 +9,15 @@
 #' - "biomarker": more strict, remove variables with more than 40% missing values,
 #'   and ensure less than 60% of missing values in all groups.
 #'
-#' @param exp A [glyexp::experiment()] object. [glyexp::GlycomicSE()] and
-#'   [glyexp::GlycoproteomicSE()] objects are also supported.
+#' @param exp A [glyexp::experiment()] or
+#'   [SummarizedExperiment::SummarizedExperiment()] object.
 #' @param preset One of "simple", "discovery", or "biomarker".
 #'   Default "discovery" if group information is available, otherwise "simple".
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
 #'
-#' @returns A modified [glyexp::experiment()] object. Glyco SE inputs return the
-#'   same subclass.
+#' @returns The filtered input container. SummarizedExperiment inputs return the
+#'   same class.
 #'
 #' @examples
 #' library(glyexp)
@@ -30,7 +30,7 @@ auto_remove <- function(
   preset = "discovery",
   group_col = "group"
 ) {
-  .assert_auto_container(exp)
+  .assert_glyclean_container(exp)
   checkmate::assert_choice(preset, c("simple", "discovery", "biomarker"))
   checkmate::assert_string(group_col, null.ok = TRUE)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -187,6 +187,10 @@
 
 #' Extract the experiment type from a glyclean container
 #'
+#' Plain `SummarizedExperiment` objects are always treated as `"others"`.
+#' Glyco experiment types require either an explicit legacy experiment type or
+#' a validated `GlycomicSE` or `GlycoproteomicSE` subclass.
+#'
 #' @param x A supported glyclean container.
 #'
 #' @return The experiment type.
@@ -201,19 +205,6 @@
   }
   if (inherits(x, "glyexp_experiment")) {
     return(glyexp::get_exp_type(x))
-  }
-
-  metadata <- S4Vectors::metadata(x)
-  if (!is.null(metadata$exp_type)) {
-    return(metadata$exp_type)
-  }
-
-  var_cols <- colnames(SummarizedExperiment::rowData(x))
-  if (all(c("protein", "protein_site") %in% var_cols)) {
-    return("glycoproteomics")
-  }
-  if (any(c("glycan_composition", "glycan_structure") %in% var_cols)) {
-    return("glycomics")
   }
   "others"
 }

--- a/man/auto_coda.Rd
+++ b/man/auto_coda.Rd
@@ -7,8 +7,8 @@
 auto_coda(x, by = NULL, gamma = 0.1, group_scales = NULL)
 }
 \arguments{
-\item{x}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} object. \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} and
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} objects are also supported.}
+\item{x}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment()}} object.}
 
 \item{by}{Either a column name in \code{sample_info} or a factor/vector with one
 value per sample.}
@@ -22,9 +22,9 @@ first, or two positive scales from which that ratio is derived. For
 multi-group data, provide a positive vector with one scale per group.}
 }
 \value{
-A \code{\link[glyexp:experiment]{glyexp::experiment()}} object with a CoDA-transformed expression
-matrix (ALR if >50 variables, CLR otherwise). Glyco SE inputs return the
-same subclass.
+The input container with a CoDA-transformed expression matrix (ALR
+if >50 variables, CLR otherwise). SummarizedExperiment inputs return the
+same class.
 }
 \description{
 If the data has more than 50 variables, call \code{\link[=transform_alr]{transform_alr()}}.

--- a/man/auto_correct_batch_effect.Rd
+++ b/man/auto_correct_batch_effect.Rd
@@ -14,8 +14,8 @@ auto_correct_batch_effect(
 )
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} object. \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} and
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} objects are also supported.}
+\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment()}} object.}
 
 \item{group_col}{The column name in sample_info for groups. Default is "group".
 Can be NULL when no group information is available.}
@@ -33,8 +33,8 @@ Default to TRUE.}
 Only used when \code{check_confounding} is TRUE. Default to 0.4.}
 }
 \value{
-A \code{\link[glyexp:experiment]{glyexp::experiment()}} object with batch effects corrected. Glyco
-SE inputs return the same subclass.
+The input container with batch effects corrected.
+SummarizedExperiment inputs return the same class.
 }
 \description{
 Detects and corrects batch effects in the experiment.

--- a/man/auto_impute.Rd
+++ b/man/auto_impute.Rd
@@ -7,15 +7,15 @@
 auto_impute(exp, group_col = "group")
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} object. \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} and
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} objects are also supported.}
+\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment()}} object.}
 
 \item{group_col}{The column name in sample_info for groups. Default is "group".
 Can be NULL when no group information is available.}
 }
 \value{
-The imputed \code{\link[glyexp:experiment]{glyexp::experiment()}} object. Glyco SE inputs return the
-same subclass.
+The imputed input container. SummarizedExperiment inputs return the
+same class.
 }
 \description{
 This function automatically selects and applies a deterministic default

--- a/man/auto_normalize.Rd
+++ b/man/auto_normalize.Rd
@@ -7,15 +7,15 @@
 auto_normalize(exp, group_col = "group")
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} object. \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} and
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} objects are also supported.}
+\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment()}} object.}
 
 \item{group_col}{The column name in sample_info for groups. Default is "group".
 Can be NULL when no group information is available.}
 }
 \value{
-The normalized \code{\link[glyexp:experiment]{glyexp::experiment()}} object. Glyco SE inputs return
-the same subclass.
+The normalized input container. SummarizedExperiment inputs return
+the same class.
 }
 \description{
 This function automatically applies a deterministic default normalization

--- a/man/auto_remove.Rd
+++ b/man/auto_remove.Rd
@@ -7,8 +7,8 @@
 auto_remove(exp, preset = "discovery", group_col = "group")
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} object. \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} and
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} objects are also supported.}
+\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment()}} object.}
 
 \item{preset}{One of "simple", "discovery", or "biomarker".
 Default "discovery" if group information is available, otherwise "simple".}
@@ -17,8 +17,8 @@ Default "discovery" if group information is available, otherwise "simple".}
 Can be NULL when no group information is available.}
 }
 \value{
-A modified \code{\link[glyexp:experiment]{glyexp::experiment()}} object. Glyco SE inputs return the
-same subclass.
+The filtered input container. SummarizedExperiment inputs return the
+same class.
 }
 \description{
 This function uses preset rules to remove variables with low quality.

--- a/tests/testthat/test-se-support.R
+++ b/tests/testthat/test-se-support.R
@@ -108,11 +108,46 @@ test_that("automatic preprocessing preserves glyco SE subclasses", {
   )
 })
 
-test_that("automatic preprocessing still requires a typed container", {
+test_that("automatic preprocessing for others accepts plain SummarizedExperiment", {
   x <- plain_se(simple_glycomic_se())
+  S4Vectors::metadata(x)$exp_type <- "others"
+
+  normalized <- suppressMessages(auto_normalize(x))
+
+  x_missing <- x
+  SummarizedExperiment::assay(x_missing)[1, 1] <- NA_real_
+  imputed <- suppressMessages(auto_impute(x_missing))
+
+  filtered <- suppressMessages(auto_remove(x, preset = "simple"))
+  transformed <- suppressMessages(auto_coda(x, gamma = 0))
+  corrected <- suppressMessages(
+    auto_correct_batch_effect(x, batch_col = NULL)
+  )
+
+  for (result in list(
+    normalized,
+    imputed,
+    filtered,
+    transformed,
+    corrected
+  )) {
+    expect_identical(as.character(class(result)), "SummarizedExperiment")
+    expect_identical(S4Vectors::metadata(result)$exp_type, "others")
+  }
+  expect_false(anyNA(SummarizedExperiment::assay(imputed)))
+})
+
+test_that("type-specific automatic preprocessing rejects plain others SE", {
+  x <- plain_se(simple_glycomic_se())
+  S4Vectors::metadata(x)$exp_type <- "others"
 
   expect_error(
-    auto_normalize(x),
+    auto_clean(x),
+    "Must inherit from class 'glyexp_experiment', 'GlycomicSE', or 'GlycoproteomicSE'",
+    fixed = TRUE
+  )
+  expect_error(
+    auto_aggregate(x, standardize_variable = FALSE),
     "Must inherit from class 'glyexp_experiment', 'GlycomicSE', or 'GlycoproteomicSE'",
     fixed = TRUE
   )

--- a/tests/testthat/test-se-support.R
+++ b/tests/testthat/test-se-support.R
@@ -110,7 +110,6 @@ test_that("automatic preprocessing preserves glyco SE subclasses", {
 
 test_that("automatic preprocessing for others accepts plain SummarizedExperiment", {
   x <- plain_se(simple_glycomic_se())
-  S4Vectors::metadata(x)$exp_type <- "others"
 
   normalized <- suppressMessages(auto_normalize(x))
 
@@ -132,14 +131,24 @@ test_that("automatic preprocessing for others accepts plain SummarizedExperiment
     corrected
   )) {
     expect_identical(as.character(class(result)), "SummarizedExperiment")
-    expect_identical(S4Vectors::metadata(result)$exp_type, "others")
+    expect_identical(glyclean:::.get_exp_type(result), "others")
   }
   expect_false(anyNA(SummarizedExperiment::assay(imputed)))
 })
 
+test_that("plain SummarizedExperiment is always treated as others", {
+  glycomic <- plain_se(simple_glycomic_se())
+  S4Vectors::metadata(glycomic)$exp_type <- "glycomics"
+
+  glycoproteomic <- plain_se(simple_glycoproteomic_se())
+  S4Vectors::metadata(glycoproteomic)$exp_type <- "glycoproteomics"
+
+  expect_identical(glyclean:::.get_exp_type(glycomic), "others")
+  expect_identical(glyclean:::.get_exp_type(glycoproteomic), "others")
+})
+
 test_that("type-specific automatic preprocessing rejects plain others SE", {
   x <- plain_se(simple_glycomic_se())
-  S4Vectors::metadata(x)$exp_type <- "others"
 
   expect_error(
     auto_clean(x),


### PR DESCRIPTION
## Summary

Allow automatic preprocessing helpers that already support `glyexp::experiment(exp_type = "others")` to also accept plain `SummarizedExperiment` inputs.

## Details

- Use the general glyclean container validator in `auto_normalize()`, `auto_impute()`, `auto_remove()`, `auto_coda()`, and `auto_correct_batch_effect()`.
- Preserve the plain `SummarizedExperiment` class and `metadata(exp_type = "others")` across these workflows.
- Keep `auto_clean()` and `auto_aggregate()` restricted to typed glycomics or glycoproteomics containers because their algorithms remain experiment-type-specific.
- Update generated documentation for the expanded input contract.
- Add regression coverage for all five supported helpers and for the retained type-specific restrictions.

## Verification

- `Rscript -e 'devtools::test(filter = "se-support")'` — 81 passed.
- `Rscript -e 'devtools::test()'` — 724 passed, 1 existing skip.
- `Rscript -e 'devtools::check()'` — 0 errors, 0 warnings, 1 environment-only clock-verification note.
- `git diff --check` — clean.