### PR TITLE
Add glycomics support to aggregate()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Imports:
     cli,
     dplyr,
     glyexp (>= 0.16.0),
+    lifecycle,
     limma,
     magrittr,
     matrixStats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `aggregate()` and `auto_aggregate()` now support glycomics data at glycan
   composition (`"g"`) and glycan structure (`"gs"`) levels, and `auto_clean()`
-  now aggregates glycomics data automatically. (#22)
+  now aggregates glycomics data automatically. (#28)
 
 # glyclean 0.15.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # glyclean (development version)
 
-* `aggregate()` and `auto_aggregate()` now support glycomics data at glycan
-  composition (`"g"`) and glycan structure (`"gs"`) levels, and `auto_clean()`
-  now aggregates glycomics data automatically. (#28)
+* `aggregate()` now supports glycomics levels `"g"` and `"gs"` and uses structure-aware defaults: `"gs"` or `"g"` for glycomics data and `"gfs"` or `"gf"` for glycoproteomics data, depending on whether `glycan_structure` is present. `auto_aggregate()` is deprecated in favor of `aggregate()`, and `auto_clean()` now aggregates glycomics data automatically. (#28)
 
 # glyclean 0.15.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyclean (development version)
 
+* `aggregate()` and `auto_aggregate()` now support glycomics data at glycan
+  composition (`"g"`) and glycan structure (`"gs"`) levels, and `auto_clean()`
+  now aggregates glycomics data automatically. (#22)
+
 # glyclean 0.15.2
 
 * Documentation and vignettes now recommend `GlycomicSE` and `GlycoproteomicSE` containers with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15. (#26)

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -44,9 +44,11 @@
 #' @param exp A glycomics or glycoproteomics container: a
 #'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()], or legacy
 #'   `glyexp_experiment` object.
-#' @param to_level The aggregation level. If `NULL` (the default), the level is
-#'   selected from the input type and whether `glycan_structure` is present.
-#'   Otherwise, one of: "g" (glycan compositions), "gs" (glycan structures),
+#' @param to_level The aggregation level. If `NULL` (the default), glycomics data
+#'   uses "gs" when `glycan_structure` is present and "g" otherwise;
+#'   glycoproteomics data uses "gfs" when `glycan_structure` is present and "gf"
+#'   otherwise. Explicit values are: "g" (glycan compositions),
+#'   "gs" (glycan structures),
 #'   "gf" (glycoforms), "gp" (glycopeptides),
 #'   "gfs" (glycoforms with structures),
 #'   or "gps" (glycopeptides with structures).

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -9,10 +9,11 @@
 #'
 #' The following levels are available:
 #' - "g": Aggregate glycomics data to glycan compositions.
+#'   This is the default level for glycomics data.
 #' - "gs": Aggregate glycomics data to glycan structures.
 #' - "gf": Aggregate to glycoforms, which is the unique combination of proteins,
 #'   protein sites, and glycan compositions.
-#'   This is the default level.
+#'   This is the default level for glycoproteomics data.
 #' - "gp": Aggregate to glycopeptides,
 #'   which is the unique combination of peptides,
 #'   proteins, protein sites, and glycan compositions.
@@ -42,8 +43,9 @@
 #' @param exp A glycomics or glycoproteomics container: a
 #'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()], or legacy
 #'   `glyexp_experiment` object.
-#' @param to_level The aggregation level,
-#'   one of: "g" (glycan compositions), "gs" (glycan structures),
+#' @param to_level The aggregation level. If `NULL` (the default), uses "g" for
+#'   glycomics data and "gf" for glycoproteomics data. Otherwise, one of:
+#'   "g" (glycan compositions), "gs" (glycan structures),
 #'   "gf" (glycoforms), "gp" (glycopeptides),
 #'   "gfs" (glycoforms with structures),
 #'   or "gps" (glycopeptides with structures).
@@ -56,7 +58,7 @@
 #' @export
 aggregate <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE
 ) {
   glyclean_aggregate(
@@ -68,7 +70,7 @@ aggregate <- function(
 
 glyclean_aggregate <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE
 ) {
   UseMethod("glyclean_aggregate")
@@ -78,7 +80,7 @@ glyclean_aggregate <- function(
 #' @export
 glyclean_aggregate.glyexp_experiment <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE
 ) {
   .aggregate_container(
@@ -93,7 +95,7 @@ glyclean_aggregate.glyexp_experiment <- function(
 #' @noRd
 glyclean_aggregate.GlycomicSE <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE
 ) {
   .aggregate_container(
@@ -108,7 +110,7 @@ glyclean_aggregate.GlycomicSE <- function(
 #' @noRd
 glyclean_aggregate.GlycoproteomicSE <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE
 ) {
   .aggregate_container(
@@ -128,14 +130,25 @@ glyclean_aggregate.GlycoproteomicSE <- function(
 #' @noRd
 .aggregate_container <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE,
   error_call = rlang::caller_call()
 ) {
   # Check arguments
   .assert_aggregation_container(exp, error_call = error_call)
-  to_level <- rlang::arg_match(to_level)
   exp_type <- .get_exp_type(exp)
+  if (is.null(to_level)) {
+    to_level <- switch(
+      exp_type,
+      glycomics = "g",
+      glycoproteomics = "gf"
+    )
+  } else {
+    to_level <- rlang::arg_match(
+      to_level,
+      c("gf", "gp", "gfs", "gps", "g", "gs")
+    )
+  }
   supported_levels <- switch(
     exp_type,
     glycomics = c("g", "gs"),
@@ -259,7 +272,7 @@ glyclean_aggregate.GlycoproteomicSE <- function(
 #' @export
 glyclean_aggregate.default <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
+  to_level = NULL,
   standardize_variable = TRUE
 ) {
   cli::cli_abort(c(

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -1,13 +1,15 @@
 #' Aggregate Data
 #'
 #' @description
-#' Aggregate glycoproteomics data to different levels
-#' (glycoforms, glycopeptides, etc.).
+#' Aggregate glycomics or glycoproteomics data to different levels
+#' (glycans, glycoforms, glycopeptides, etc.).
 #' This function sums up quantitative values for each
 #' unique combination of specified variables.
 #' It is recommended to call this function after missing value imputation.
 #'
 #' The following levels are available:
+#' - "g": Aggregate glycomics data to glycan compositions.
+#' - "gs": Aggregate glycomics data to glycan structures.
 #' - "gf": Aggregate to glycoforms, which is the unique combination of proteins,
 #'   protein sites, and glycan compositions.
 #'   This is the default level.
@@ -17,7 +19,12 @@
 #' - "gfs": Like "gf", but differentiates structures with the same composition.
 #' - "gps": Like "gp", but differentiates structures with the same composition.
 #'
+#' The "g" and "gs" levels are available for glycomics data. The "gf", "gp",
+#' "gfs", and "gps" levels are available for glycoproteomics data.
+#'
 #' Different levels of aggregation require different columns in the variable information.
+#' - "g": "glycan_composition"
+#' - "gs": "glycan_composition", "glycan_structure"
 #' - "gf": "protein", "glycan_composition", "protein_site"
 #' - "gp": "peptide", "protein", "glycan_composition", "peptide_site", "protein_site"
 #' - "gfs": "protein", "glycan_composition", "glycan_structure", "protein_site"
@@ -32,9 +39,12 @@
 #' On the other hand, the "peptide" column is removed for "gf" level,
 #' as one "glycoform" can contain multiple "peptides".
 #'
-#' @param exp A [glyexp::GlycoproteomicSE()] object.
+#' @param exp A glycomics or glycoproteomics container: a
+#'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()], or legacy
+#'   `glyexp_experiment` object.
 #' @param to_level The aggregation level,
-#'   one of: "gf" (glycoforms), "gp" (glycopeptides),
+#'   one of: "g" (glycan compositions), "gs" (glycan structures),
+#'   "gf" (glycoforms), "gp" (glycopeptides),
 #'   "gfs" (glycoforms with structures),
 #'   or "gps" (glycopeptides with structures).
 #'   See Details for more information.
@@ -46,7 +56,7 @@
 #' @export
 aggregate <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 ) {
   glyclean_aggregate(
@@ -58,7 +68,7 @@ aggregate <- function(
 
 glyclean_aggregate <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 ) {
   UseMethod("glyclean_aggregate")
@@ -68,7 +78,7 @@ glyclean_aggregate <- function(
 #' @export
 glyclean_aggregate.glyexp_experiment <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 ) {
   .aggregate_container(
@@ -83,7 +93,7 @@ glyclean_aggregate.glyexp_experiment <- function(
 #' @noRd
 glyclean_aggregate.GlycomicSE <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 ) {
   .aggregate_container(
@@ -98,7 +108,7 @@ glyclean_aggregate.GlycomicSE <- function(
 #' @noRd
 glyclean_aggregate.GlycoproteomicSE <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 ) {
   .aggregate_container(
@@ -109,7 +119,7 @@ glyclean_aggregate.GlycoproteomicSE <- function(
   )
 }
 
-#' Aggregate a supported glycoproteomics container
+#' Aggregate a supported glycomics or glycoproteomics container
 #'
 #' @inheritParams aggregate
 #' @param error_call The call to use in error messages.
@@ -118,17 +128,35 @@ glyclean_aggregate.GlycoproteomicSE <- function(
 #' @noRd
 .aggregate_container <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE,
   error_call = rlang::caller_call()
 ) {
   # Check arguments
-  .assert_glycoproteomics_container(exp, error_call = error_call)
+  .assert_aggregation_container(exp, error_call = error_call)
   to_level <- rlang::arg_match(to_level)
+  exp_type <- .get_exp_type(exp)
+  supported_levels <- switch(
+    exp_type,
+    glycomics = c("g", "gs"),
+    glycoproteomics = c("gf", "gp", "gfs", "gps")
+  )
+  if (!to_level %in% supported_levels) {
+    cli::cli_abort(
+      c(
+        "The aggregation level must match the experiment type.",
+        "i" = "{.val {exp_type}} data supports {.val {supported_levels}}.",
+        "x" = "Got {.val {to_level}}."
+      ),
+      call = error_call
+    )
+  }
 
   # Perform aggregation
   var_info_cols <- switch(
     to_level,
+    g = "glycan_composition",
+    gs = c("glycan_composition", "glycan_structure"),
     gf = c("protein", "glycan_composition", "protein_site"),
     gp = c(
       "peptide",
@@ -157,12 +185,17 @@ glyclean_aggregate.GlycoproteomicSE <- function(
   if (length(missing_cols) > 0) {
     if (length(missing_cols) == 1 && missing_cols == "glycan_structure") {
       # special case for missing "glycan_structure" column
+      fallback_message <- if (exp_type == "glycomics") {
+        "You might want to aggregate to {.val g} level."
+      } else {
+        "You might want to aggregate to {.val gp} or {.val gf} level."
+      }
       cli::cli_abort(
         c(
           "All required columns must be present in `var_info`.",
           "i" = "Required columns: {.field {var_info_cols}}.",
           "x" = "Missing columns: {.field {missing_cols}}.",
-          "i" = "You might want to aggregate to {.val gp} or {.val gf} level."
+          "i" = fallback_message
         ),
         call = error_call
       )
@@ -226,11 +259,14 @@ glyclean_aggregate.GlycoproteomicSE <- function(
 #' @export
 glyclean_aggregate.default <- function(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 ) {
   cli::cli_abort(c(
-    "{.arg exp} must be a {.cls glyexp_experiment} object or a {.cls GlycoproteomicSE} object.",
+    paste0(
+      "{.arg exp} must be a {.cls glyexp_experiment}, {.cls GlycomicSE}, ",
+      "or {.cls GlycoproteomicSE} object."
+    ),
     "x" = "Got {.cls {class(exp)}}."
   ))
 }

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -9,11 +9,9 @@
 #'
 #' The following levels are available:
 #' - "g": Aggregate glycomics data to glycan compositions.
-#'   This is the default level for glycomics data.
 #' - "gs": Aggregate glycomics data to glycan structures.
 #' - "gf": Aggregate to glycoforms, which is the unique combination of proteins,
 #'   protein sites, and glycan compositions.
-#'   This is the default level for glycoproteomics data.
 #' - "gp": Aggregate to glycopeptides,
 #'   which is the unique combination of peptides,
 #'   proteins, protein sites, and glycan compositions.
@@ -22,6 +20,9 @@
 #'
 #' The "g" and "gs" levels are available for glycomics data. The "gf", "gp",
 #' "gfs", and "gps" levels are available for glycoproteomics data.
+#' When `to_level = NULL`, glycomics data defaults to "gs" when
+#' `glycan_structure` is present and "g" otherwise. Glycoproteomics data
+#' similarly defaults to "gfs" or "gf".
 #'
 #' Different levels of aggregation require different columns in the variable information.
 #' - "g": "glycan_composition"
@@ -43,9 +44,9 @@
 #' @param exp A glycomics or glycoproteomics container: a
 #'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()], or legacy
 #'   `glyexp_experiment` object.
-#' @param to_level The aggregation level. If `NULL` (the default), uses "g" for
-#'   glycomics data and "gf" for glycoproteomics data. Otherwise, one of:
-#'   "g" (glycan compositions), "gs" (glycan structures),
+#' @param to_level The aggregation level. If `NULL` (the default), the level is
+#'   selected from the input type and whether `glycan_structure` is present.
+#'   Otherwise, one of: "g" (glycan compositions), "gs" (glycan structures),
 #'   "gf" (glycoforms), "gp" (glycopeptides),
 #'   "gfs" (glycoforms with structures),
 #'   or "gps" (glycopeptides with structures).
@@ -137,11 +138,13 @@ glyclean_aggregate.GlycoproteomicSE <- function(
   # Check arguments
   .assert_aggregation_container(exp, error_call = error_call)
   exp_type <- .get_exp_type(exp)
+  var_info <- .get_var_info(exp)
   if (is.null(to_level)) {
+    has_structure <- "glycan_structure" %in% colnames(var_info)
     to_level <- switch(
       exp_type,
-      glycomics = "g",
-      glycoproteomics = "gf"
+      glycomics = if (has_structure) "gs" else "g",
+      glycoproteomics = if (has_structure) "gfs" else "gf"
     )
   } else {
     to_level <- rlang::arg_match(
@@ -193,7 +196,6 @@ glyclean_aggregate.GlycoproteomicSE <- function(
       "protein_site"
     )
   )
-  var_info <- .get_var_info(exp)
   missing_cols <- setdiff(var_info_cols, colnames(var_info))
   if (length(missing_cols) > 0) {
     if (length(missing_cols) == 1 && missing_cols == "glycan_structure") {

--- a/R/auto-aggregate.R
+++ b/R/auto-aggregate.R
@@ -1,9 +1,11 @@
 #' Automatic Aggregation
 #'
-#' Aggregates glycomics or glycoproteomics data to a structure-aware level when
-#' the glycan structure column exists, and to a composition-only level otherwise.
-#' Glycomics data is aggregated to "gs" or "g"; glycoproteomics data is
-#' aggregated to "gfs" or "gf".
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' `auto_aggregate()` was deprecated in glyclean 0.15.3. Use [aggregate()]
+#' instead; it now selects the aggregation level from the input type and whether
+#' `glycan_structure` is present.
 #'
 #' @param exp A glycomics or glycoproteomics container: a
 #'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()], or legacy
@@ -18,29 +20,18 @@
 #' @examples
 #' library(glyexp)
 #' exp <- real_experiment
-#' auto_aggregate(exp)
+#' # Deprecated:
+#' # auto_aggregate(exp)
 #'
+#' # Use instead:
+#' aggregate(exp)
+#'
+#' @keywords internal
 #' @export
 auto_aggregate <- function(exp, standardize_variable = TRUE) {
-  .assert_auto_container(exp)
-  exp_type <- .get_exp_type(exp)
-  if (!exp_type %in% c("glycomics", "glycoproteomics")) {
-    cli::cli_abort(c(
-      "The experiment type must be {.val glycomics} or {.val glycoproteomics}.",
-      "x" = "Got {.val {exp_type}}."
-    ))
-  }
-  has_structure <- "glycan_structure" %in% colnames(.get_var_info(exp))
-  to_level <- if (exp_type == "glycomics") {
-    if (has_structure) "gs" else "g"
-  } else {
-    if (has_structure) "gfs" else "gf"
-  }
-  cli::cli_alert_info("Aggregating to {.val {to_level}} level")
-  .aggregate_container(
+  lifecycle::deprecate_warn("0.15.3", "auto_aggregate()", "aggregate()")
+  aggregate(
     exp,
-    to_level = to_level,
-    standardize_variable = standardize_variable,
-    error_call = rlang::caller_call()
+    standardize_variable = standardize_variable
   )
 }

--- a/R/auto-aggregate.R
+++ b/R/auto-aggregate.R
@@ -1,10 +1,13 @@
 #' Automatic Aggregation
 #'
-#' Aggregates glycoproteomics data to "gfs" (glycoforms with structures) level
-#' if the glycan structure column exists,
-#' otherwise to "gf" (glycoforms with compositions) level.
+#' Aggregates glycomics or glycoproteomics data to a structure-aware level when
+#' the glycan structure column exists, and to a composition-only level otherwise.
+#' Glycomics data is aggregated to "gs" or "g"; glycoproteomics data is
+#' aggregated to "gfs" or "gf".
 #'
-#' @param exp A [glyexp::GlycoproteomicSE()] object.
+#' @param exp A glycomics or glycoproteomics container: a
+#'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()], or legacy
+#'   `glyexp_experiment` object.
 #' @param standardize_variable Whether to call [glyexp::standardize_variable()]
 #'   after aggregation. Set to `FALSE` to skip network calls for faster testing.
 #'   Default is `TRUE`.
@@ -21,27 +24,23 @@
 auto_aggregate <- function(exp, standardize_variable = TRUE) {
   .assert_auto_container(exp)
   exp_type <- .get_exp_type(exp)
-  if (exp_type != "glycoproteomics") {
+  if (!exp_type %in% c("glycomics", "glycoproteomics")) {
     cli::cli_abort(c(
-      "The experiment type must be {.val glycoproteomics}.",
+      "The experiment type must be {.val glycomics} or {.val glycoproteomics}.",
       "x" = "Got {.val {exp_type}}."
     ))
   }
-  if ("glycan_structure" %in% colnames(.get_var_info(exp))) {
-    cli::cli_alert_info("Aggregating to {.val gfs} level")
-    .aggregate_container(
-      exp,
-      to_level = "gfs",
-      standardize_variable = standardize_variable,
-      error_call = rlang::caller_call()
-    )
+  has_structure <- "glycan_structure" %in% colnames(.get_var_info(exp))
+  to_level <- if (exp_type == "glycomics") {
+    if (has_structure) "gs" else "g"
   } else {
-    cli::cli_alert_info("Aggregating to {.val gf} level")
-    .aggregate_container(
-      exp,
-      to_level = "gf",
-      standardize_variable = standardize_variable,
-      error_call = rlang::caller_call()
-    )
+    if (has_structure) "gfs" else "gf"
   }
+  cli::cli_alert_info("Aggregating to {.val {to_level}} level")
+  .aggregate_container(
+    exp,
+    to_level = to_level,
+    standardize_variable = standardize_variable,
+    error_call = rlang::caller_call()
+  )
 }

--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -9,7 +9,7 @@
 #' For glycomics data, this function calls these functions in sequence:
 #' - [auto_remove()]
 #' - [auto_impute()]
-#' - [auto_aggregate()]
+#' - [aggregate()]
 #' - [auto_normalize()]
 #' - [auto_correct_batch_effect()]
 #'
@@ -17,7 +17,7 @@
 #' - [auto_remove()]
 #' - [auto_normalize()]
 #' - [auto_impute()]
-#' - [auto_aggregate()]
+#' - [aggregate()]
 #' - [auto_normalize()]
 #' - [auto_correct_batch_effect()]
 #'
@@ -50,7 +50,8 @@
 #' exp <- real_experiment
 #' auto_clean(exp)
 #'
-#' @seealso [auto_normalize()], [auto_remove()], [auto_impute()], [auto_aggregate()], [auto_correct_batch_effect()]
+#' @seealso [auto_normalize()], [auto_remove()], [auto_impute()], [aggregate()],
+#'   [auto_correct_batch_effect()]
 #' @export
 auto_clean <- function(
   exp,
@@ -117,7 +118,7 @@ auto_clean <- function(
   cli::cli_alert_success("Imputation completed.")
 
   cli::cli_h2("Aggregating data")
-  exp <- auto_aggregate(exp, standardize_variable = params$standardize_variable)
+  exp <- aggregate(exp, standardize_variable = params$standardize_variable)
   cli::cli_alert_success("Aggregation completed.")
 
   cli::cli_h2("Normalizing data again")
@@ -157,7 +158,7 @@ auto_clean <- function(
   cli::cli_alert_success("Imputation completed.")
 
   cli::cli_h2("Aggregating data")
-  exp <- auto_aggregate(exp, standardize_variable = params$standardize_variable)
+  exp <- aggregate(exp, standardize_variable = params$standardize_variable)
   cli::cli_alert_success("Aggregation completed.")
 
   cli::cli_h2("Normalizing data")

--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -3,12 +3,13 @@
 #' @description
 #' Perform automatic data preprocessing on glycoproteomics or glycomics data.
 #' This function applies an intelligent preprocessing pipeline that includes
-#' normalization, missing value handling, imputation, aggregation (for
-#' glycoproteomics data), and batch effect correction.
+#' normalization, missing value handling, imputation, aggregation, and batch
+#' effect correction.
 #'
 #' For glycomics data, this function calls these functions in sequence:
 #' - [auto_remove()]
 #' - [auto_impute()]
+#' - [auto_aggregate()]
 #' - [auto_normalize()]
 #' - [auto_correct_batch_effect()]
 #'
@@ -154,6 +155,10 @@ auto_clean <- function(
     params$group_col
   )
   cli::cli_alert_success("Imputation completed.")
+
+  cli::cli_h2("Aggregating data")
+  exp <- auto_aggregate(exp, standardize_variable = params$standardize_variable)
+  cli::cli_alert_success("Aggregation completed.")
 
   cli::cli_h2("Normalizing data")
   exp <- auto_normalize(

--- a/R/utils.R
+++ b/R/utils.R
@@ -249,6 +249,31 @@
   invisible(x)
 }
 
+#' Require a glycomics or glycoproteomics container
+#'
+#' @param x A supported glyclean container.
+#' @param error_call The call to use in error messages.
+#'
+#' @return `x`, invisibly.
+#' @noRd
+.assert_aggregation_container <- function(
+  x,
+  error_call = rlang::caller_call()
+) {
+  .assert_glyclean_container(x)
+  exp_type <- .get_exp_type(x)
+  if (!exp_type %in% c("glycomics", "glycoproteomics")) {
+    cli::cli_abort(
+      c(
+        "The experiment type must be {.val glycomics} or {.val glycoproteomics}.",
+        "x" = "Got {.val {exp_type}}."
+      ),
+      call = error_call
+    )
+  }
+  invisible(x)
+}
+
 #' Extract container metadata
 #'
 #' @param x A supported glyclean container.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,7 +9,6 @@ reference:
   - title: Automactic Processing
     contents:
       - auto_clean
-      - auto_aggregate
       - auto_impute
       - auto_normalize
       - auto_remove

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -6,31 +6,20 @@
 \alias{glyclean_aggregate.default}
 \title{Aggregate Data}
 \usage{
-aggregate(
-  exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
-  standardize_variable = TRUE
-)
+aggregate(exp, to_level = NULL, standardize_variable = TRUE)
 
-\method{glyclean_aggregate}{glyexp_experiment}(
-  exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
-  standardize_variable = TRUE
-)
+\method{glyclean_aggregate}{glyexp_experiment}(exp, to_level = NULL, standardize_variable = TRUE)
 
-\method{glyclean_aggregate}{default}(
-  exp,
-  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
-  standardize_variable = TRUE
-)
+\method{glyclean_aggregate}{default}(exp, to_level = NULL, standardize_variable = TRUE)
 }
 \arguments{
 \item{exp}{A glycomics or glycoproteomics container: a
 \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or legacy
 \code{glyexp_experiment} object.}
 
-\item{to_level}{The aggregation level,
-one of: "g" (glycan compositions), "gs" (glycan structures),
+\item{to_level}{The aggregation level. If \code{NULL} (the default), uses "g" for
+glycomics data and "gf" for glycoproteomics data. Otherwise, one of:
+"g" (glycan compositions), "gs" (glycan structures),
 "gf" (glycoforms), "gp" (glycopeptides),
 "gfs" (glycoforms with structures),
 or "gps" (glycopeptides with structures).
@@ -54,10 +43,11 @@ It is recommended to call this function after missing value imputation.
 The following levels are available:
 \itemize{
 \item "g": Aggregate glycomics data to glycan compositions.
+This is the default level for glycomics data.
 \item "gs": Aggregate glycomics data to glycan structures.
 \item "gf": Aggregate to glycoforms, which is the unique combination of proteins,
 protein sites, and glycan compositions.
-This is the default level.
+This is the default level for glycoproteomics data.
 \item "gp": Aggregate to glycopeptides,
 which is the unique combination of peptides,
 proteins, protein sites, and glycan compositions.

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -17,9 +17,11 @@ aggregate(exp, to_level = NULL, standardize_variable = TRUE)
 \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or legacy
 \code{glyexp_experiment} object.}
 
-\item{to_level}{The aggregation level. If \code{NULL} (the default), the level is
-selected from the input type and whether \code{glycan_structure} is present.
-Otherwise, one of: "g" (glycan compositions), "gs" (glycan structures),
+\item{to_level}{The aggregation level. If \code{NULL} (the default), glycomics data
+uses "gs" when \code{glycan_structure} is present and "g" otherwise;
+glycoproteomics data uses "gfs" when \code{glycan_structure} is present and "gf"
+otherwise. Explicit values are: "g" (glycan compositions),
+"gs" (glycan structures),
 "gf" (glycoforms), "gp" (glycopeptides),
 "gfs" (glycoforms with structures),
 or "gps" (glycopeptides with structures).

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -8,27 +8,30 @@
 \usage{
 aggregate(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 )
 
 \method{glyclean_aggregate}{glyexp_experiment}(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 )
 
 \method{glyclean_aggregate}{default}(
   exp,
-  to_level = c("gf", "gp", "gfs", "gps"),
+  to_level = c("gf", "gp", "gfs", "gps", "g", "gs"),
   standardize_variable = TRUE
 )
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.}
+\item{exp}{A glycomics or glycoproteomics container: a
+\code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or legacy
+\code{glyexp_experiment} object.}
 
 \item{to_level}{The aggregation level,
-one of: "gf" (glycoforms), "gp" (glycopeptides),
+one of: "g" (glycan compositions), "gs" (glycan structures),
+"gf" (glycoforms), "gp" (glycopeptides),
 "gfs" (glycoforms with structures),
 or "gps" (glycopeptides with structures).
 See Details for more information.}
@@ -42,14 +45,16 @@ A modified container with the same class as \code{exp}, an aggregated
 expression matrix, and updated variable information.
 }
 \description{
-Aggregate glycoproteomics data to different levels
-(glycoforms, glycopeptides, etc.).
+Aggregate glycomics or glycoproteomics data to different levels
+(glycans, glycoforms, glycopeptides, etc.).
 This function sums up quantitative values for each
 unique combination of specified variables.
 It is recommended to call this function after missing value imputation.
 
 The following levels are available:
 \itemize{
+\item "g": Aggregate glycomics data to glycan compositions.
+\item "gs": Aggregate glycomics data to glycan structures.
 \item "gf": Aggregate to glycoforms, which is the unique combination of proteins,
 protein sites, and glycan compositions.
 This is the default level.
@@ -60,8 +65,13 @@ proteins, protein sites, and glycan compositions.
 \item "gps": Like "gp", but differentiates structures with the same composition.
 }
 
+The "g" and "gs" levels are available for glycomics data. The "gf", "gp",
+"gfs", and "gps" levels are available for glycoproteomics data.
+
 Different levels of aggregation require different columns in the variable information.
 \itemize{
+\item "g": "glycan_composition"
+\item "gs": "glycan_composition", "glycan_structure"
 \item "gf": "protein", "glycan_composition", "protein_site"
 \item "gp": "peptide", "protein", "glycan_composition", "peptide_site", "protein_site"
 \item "gfs": "protein", "glycan_composition", "glycan_structure", "protein_site"

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -17,9 +17,9 @@ aggregate(exp, to_level = NULL, standardize_variable = TRUE)
 \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or legacy
 \code{glyexp_experiment} object.}
 
-\item{to_level}{The aggregation level. If \code{NULL} (the default), uses "g" for
-glycomics data and "gf" for glycoproteomics data. Otherwise, one of:
-"g" (glycan compositions), "gs" (glycan structures),
+\item{to_level}{The aggregation level. If \code{NULL} (the default), the level is
+selected from the input type and whether \code{glycan_structure} is present.
+Otherwise, one of: "g" (glycan compositions), "gs" (glycan structures),
 "gf" (glycoforms), "gp" (glycopeptides),
 "gfs" (glycoforms with structures),
 or "gps" (glycopeptides with structures).
@@ -43,11 +43,9 @@ It is recommended to call this function after missing value imputation.
 The following levels are available:
 \itemize{
 \item "g": Aggregate glycomics data to glycan compositions.
-This is the default level for glycomics data.
 \item "gs": Aggregate glycomics data to glycan structures.
 \item "gf": Aggregate to glycoforms, which is the unique combination of proteins,
 protein sites, and glycan compositions.
-This is the default level for glycoproteomics data.
 \item "gp": Aggregate to glycopeptides,
 which is the unique combination of peptides,
 proteins, protein sites, and glycan compositions.
@@ -57,6 +55,9 @@ proteins, protein sites, and glycan compositions.
 
 The "g" and "gs" levels are available for glycomics data. The "gf", "gp",
 "gfs", and "gps" levels are available for glycoproteomics data.
+When \code{to_level = NULL}, glycomics data defaults to "gs" when
+\code{glycan_structure} is present and "g" otherwise. Glycoproteomics data
+similarly defaults to "gfs" or "gf".
 
 Different levels of aggregation require different columns in the variable information.
 \itemize{

--- a/man/auto_aggregate.Rd
+++ b/man/auto_aggregate.Rd
@@ -20,14 +20,20 @@ A modified container with the same class as \code{exp}, an aggregated
 expression matrix, and updated variable information.
 }
 \description{
-Aggregates glycomics or glycoproteomics data to a structure-aware level when
-the glycan structure column exists, and to a composition-only level otherwise.
-Glycomics data is aggregated to "gs" or "g"; glycoproteomics data is
-aggregated to "gfs" or "gf".
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+\code{auto_aggregate()} was deprecated in glyclean 0.15.3. Use \code{\link[=aggregate]{aggregate()}}
+instead; it now selects the aggregation level from the input type and whether
+\code{glycan_structure} is present.
 }
 \examples{
 library(glyexp)
 exp <- real_experiment
-auto_aggregate(exp)
+# Deprecated:
+# auto_aggregate(exp)
+
+# Use instead:
+aggregate(exp)
 
 }
+\keyword{internal}

--- a/man/auto_aggregate.Rd
+++ b/man/auto_aggregate.Rd
@@ -7,7 +7,9 @@
 auto_aggregate(exp, standardize_variable = TRUE)
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.}
+\item{exp}{A glycomics or glycoproteomics container: a
+\code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or legacy
+\code{glyexp_experiment} object.}
 
 \item{standardize_variable}{Whether to call \code{\link[glyexp:standardize_variable]{glyexp::standardize_variable()}}
 after aggregation. Set to \code{FALSE} to skip network calls for faster testing.
@@ -18,9 +20,10 @@ A modified container with the same class as \code{exp}, an aggregated
 expression matrix, and updated variable information.
 }
 \description{
-Aggregates glycoproteomics data to "gfs" (glycoforms with structures) level
-if the glycan structure column exists,
-otherwise to "gf" (glycoforms with compositions) level.
+Aggregates glycomics or glycoproteomics data to a structure-aware level when
+the glycan structure column exists, and to a composition-only level otherwise.
+Glycomics data is aggregated to "gs" or "g"; glycoproteomics data is
+aggregated to "gfs" or "gf".
 }
 \examples{
 library(glyexp)

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -60,7 +60,7 @@ For glycomics data, this function calls these functions in sequence:
 \itemize{
 \item \code{\link[=auto_remove]{auto_remove()}}
 \item \code{\link[=auto_impute]{auto_impute()}}
-\item \code{\link[=auto_aggregate]{auto_aggregate()}}
+\item \code{\link[=aggregate]{aggregate()}}
 \item \code{\link[=auto_normalize]{auto_normalize()}}
 \item \code{\link[=auto_correct_batch_effect]{auto_correct_batch_effect()}}
 }
@@ -70,7 +70,7 @@ For glycoproteomics data, this function calls these functions in sequence:
 \item \code{\link[=auto_remove]{auto_remove()}}
 \item \code{\link[=auto_normalize]{auto_normalize()}}
 \item \code{\link[=auto_impute]{auto_impute()}}
-\item \code{\link[=auto_aggregate]{auto_aggregate()}}
+\item \code{\link[=aggregate]{aggregate()}}
 \item \code{\link[=auto_normalize]{auto_normalize()}}
 \item \code{\link[=auto_correct_batch_effect]{auto_correct_batch_effect()}}
 }
@@ -82,5 +82,6 @@ auto_clean(exp)
 
 }
 \seealso{
-\code{\link[=auto_normalize]{auto_normalize()}}, \code{\link[=auto_remove]{auto_remove()}}, \code{\link[=auto_impute]{auto_impute()}}, \code{\link[=auto_aggregate]{auto_aggregate()}}, \code{\link[=auto_correct_batch_effect]{auto_correct_batch_effect()}}
+\code{\link[=auto_normalize]{auto_normalize()}}, \code{\link[=auto_remove]{auto_remove()}}, \code{\link[=auto_impute]{auto_impute()}}, \code{\link[=aggregate]{aggregate()}},
+\code{\link[=auto_correct_batch_effect]{auto_correct_batch_effect()}}
 }

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -53,13 +53,14 @@ A modified container with the same subclass as \code{exp}.
 \description{
 Perform automatic data preprocessing on glycoproteomics or glycomics data.
 This function applies an intelligent preprocessing pipeline that includes
-normalization, missing value handling, imputation, aggregation (for
-glycoproteomics data), and batch effect correction.
+normalization, missing value handling, imputation, aggregation, and batch
+effect correction.
 
 For glycomics data, this function calls these functions in sequence:
 \itemize{
 \item \code{\link[=auto_remove]{auto_remove()}}
 \item \code{\link[=auto_impute]{auto_impute()}}
+\item \code{\link[=auto_aggregate]{auto_aggregate()}}
 \item \code{\link[=auto_normalize]{auto_normalize()}}
 \item \code{\link[=auto_correct_batch_effect]{auto_correct_batch_effect()}}
 }

--- a/tests/testthat/_snaps/aggregate.md
+++ b/tests/testthat/_snaps/aggregate.md
@@ -1,3 +1,35 @@
+# aggregation levels must match the experiment type
+
+    Code
+      aggregate(aggregation_glycomic_se(), to_level = "gf", standardize_variable = FALSE)
+    Condition
+      Error in `glyclean_aggregate()`:
+      ! The aggregation level must match the experiment type.
+      i "glycomics" data supports "g" and "gs".
+      x Got "gf".
+
+---
+
+    Code
+      aggregate(complex_exp(), to_level = "g", standardize_variable = FALSE)
+    Condition
+      Error in `glyclean_aggregate()`:
+      ! The aggregation level must match the experiment type.
+      i "glycoproteomics" data supports "gf", "gp", "gfs", and "gps".
+      x Got "g".
+
+# glycomics structure aggregation requires glycan structures
+
+    Code
+      aggregate(aggregation_glycomic_se(include_structure = FALSE), to_level = "gs",
+      standardize_variable = FALSE)
+    Condition
+      Error in `glyclean_aggregate()`:
+      ! All required columns must be present in `var_info`.
+      i Required columns: glycan_composition and glycan_structure.
+      x Missing columns: glycan_structure.
+      i You might want to aggregate to "g" level.
+
 # aggregating from glycoforms to glycopeptides fails
 
     Code

--- a/tests/testthat/_snaps/auto-aggregate.md
+++ b/tests/testthat/_snaps/auto-aggregate.md
@@ -1,0 +1,8 @@
+# auto_aggregate is deprecated in favor of aggregate
+
+    Code
+      result <- auto_aggregate(exp, standardize_variable = FALSE)
+    Condition
+      Warning:
+      `auto_aggregate()` was deprecated in glyclean 0.15.3.
+      i Please use `aggregate()` instead.

--- a/tests/testthat/_snaps/auto-aggregate.md
+++ b/tests/testthat/_snaps/auto-aggregate.md
@@ -1,9 +1,0 @@
-# auto_aggregate rejects non-glycoproteomics experiments
-
-    Code
-      auto_aggregate(exp)
-    Condition
-      Error in `auto_aggregate()`:
-      ! The experiment type must be "glycoproteomics".
-      x Got "glycomics".
-

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -81,7 +81,7 @@
 # auto_clean works for glycomics data
 
     Code
-      result_exp <- auto_clean(test_exp)
+      result_exp <- auto_clean(test_exp, standardize_variable = FALSE)
     Message
       
       -- Removing variables with too many missing values --
@@ -95,6 +95,11 @@
       i Imputation method: `impute_min_prob()`
       i Reason: default for "glycomics" with n_samples < 30.
       v Imputation completed.
+      
+      -- Aggregating data --
+      
+      i Aggregating to "g" level
+      v Aggregation completed.
       
       -- Normalizing data --
       
@@ -110,7 +115,7 @@
 # auto_clean works for glycomics data with QC
 
     Code
-      result_exp <- auto_clean(test_exp)
+      result_exp <- auto_clean(test_exp, standardize_variable = FALSE)
     Message
       
       -- Removing variables with too many missing values --
@@ -124,6 +129,11 @@
       i Imputation method: `impute_min_prob()`
       i Reason: default for "glycomics" with n_samples < 30.
       v Imputation completed.
+      
+      -- Aggregating data --
+      
+      i Aggregating to "g" level
+      v Aggregation completed.
       
       -- Normalizing data --
       

--- a/tests/testthat/_snaps/auto-clean.md
+++ b/tests/testthat/_snaps/auto-clean.md
@@ -24,7 +24,6 @@
       
       -- Aggregating data --
       
-      i Aggregating to "gfs" level
       v Aggregation completed.
       
       -- Normalizing data again --
@@ -64,7 +63,6 @@
       
       -- Aggregating data --
       
-      i Aggregating to "gfs" level
       v Aggregation completed.
       
       -- Normalizing data again --
@@ -98,7 +96,6 @@
       
       -- Aggregating data --
       
-      i Aggregating to "g" level
       v Aggregation completed.
       
       -- Normalizing data --
@@ -132,7 +129,6 @@
       
       -- Aggregating data --
       
-      i Aggregating to "g" level
       v Aggregation completed.
       
       -- Normalizing data --

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -164,6 +164,29 @@ real_glycomic_exp <- function() {
   glyexp::as_glycomic_se(glyexp::real_experiment2)
 }
 
+aggregation_glycomic_se <- function(include_structure = TRUE) {
+  sample_info <- tibble::tibble(sample = c("S1", "S2"))
+  var_info <- tibble::tibble(
+    variable = paste0("V", 1:4),
+    glycan_composition = glyrepr::as_glycan_composition(
+      c("H5N2", "H5N2", "H5N2", "H3N2")
+    ),
+    source = c("A", "A", "B", "C")
+  )
+  if (include_structure) {
+    structures <- SummarizedExperiment::rowData(
+      glyexp::as_glycomic_se(glyexp::real_experiment2)
+    )$glycan_structure
+    var_info$glycan_structure <- structures[c(1, 1, 2, 3)]
+  }
+  expr_mat <- matrix(
+    1:8,
+    nrow = 4,
+    dimnames = list(var_info$variable, sample_info$sample)
+  )
+  test_glycomic_se(expr_mat, sample_info, var_info, glycan_type = "N")
+}
+
 expect_glyco_se <- function(x) {
   testthat::expect_true(
     glyexp::is_glycomic_se(x) || glyexp::is_glycoproteomic_se(x)

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -23,6 +23,48 @@ test_that("aggregating to glycoforms works", {
   )
 })
 
+test_that("default aggregation level depends on experiment type", {
+  expect_null(formals(aggregate)$to_level)
+
+  glycomics_exp <- aggregation_glycomic_se()
+  glycomics <- aggregate(
+    glycomics_exp,
+    standardize_variable = FALSE
+  )
+  expected_glycomics <- aggregate(
+    glycomics_exp,
+    to_level = "g",
+    standardize_variable = FALSE
+  )
+  glycoproteomics_exp <- complex_exp()
+  glycoproteomics <- aggregate(
+    glycoproteomics_exp,
+    standardize_variable = FALSE
+  )
+  expected_glycoproteomics <- aggregate(
+    glycoproteomics_exp,
+    to_level = "gf",
+    standardize_variable = FALSE
+  )
+
+  expect_equal(
+    SummarizedExperiment::assay(glycomics),
+    SummarizedExperiment::assay(expected_glycomics)
+  )
+  expect_equal(
+    SummarizedExperiment::rowData(glycomics),
+    SummarizedExperiment::rowData(expected_glycomics)
+  )
+  expect_equal(
+    SummarizedExperiment::assay(glycoproteomics),
+    SummarizedExperiment::assay(expected_glycoproteomics)
+  )
+  expect_equal(
+    SummarizedExperiment::rowData(glycoproteomics),
+    SummarizedExperiment::rowData(expected_glycoproteomics)
+  )
+})
+
 test_that("aggregation preserves group order, missing-value sums, and metadata", {
   exp <- complex_exp()
   input_mat <- SummarizedExperiment::assay(exp)
@@ -113,11 +155,11 @@ test_that("glycomics aggregation supports legacy experiments", {
     )
   )
 
-  result <- aggregate(exp, to_level = "gs", standardize_variable = FALSE)
+  result <- aggregate(exp, standardize_variable = FALSE)
 
   expect_s3_class(result, "glyexp_experiment")
   expect_identical(result$meta_data$exp_type, "glycomics")
-  expect_equal(nrow(result$expr_mat), 3L)
+  expect_equal(nrow(result$expr_mat), 2L)
 })
 
 test_that("aggregation levels must match the experiment type", {

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -26,43 +26,36 @@ test_that("aggregating to glycoforms works", {
 test_that("default aggregation level depends on experiment type", {
   expect_null(formals(aggregate)$to_level)
 
-  glycomics_exp <- aggregation_glycomic_se()
-  glycomics <- aggregate(
-    glycomics_exp,
-    standardize_variable = FALSE
+  glycomics_without_structure <- aggregation_glycomic_se(
+    include_structure = FALSE
   )
-  expected_glycomics <- aggregate(
-    glycomics_exp,
-    to_level = "g",
-    standardize_variable = FALSE
-  )
-  glycoproteomics_exp <- complex_exp()
-  glycoproteomics <- aggregate(
-    glycoproteomics_exp,
-    standardize_variable = FALSE
-  )
-  expected_glycoproteomics <- aggregate(
-    glycoproteomics_exp,
-    to_level = "gf",
-    standardize_variable = FALSE
+  glycoproteomics_without_structure <- complex_exp()
+  SummarizedExperiment::rowData(
+    glycoproteomics_without_structure
+  )$glycan_structure <- NULL
+  cases <- list(
+    list(exp = aggregation_glycomic_se(), level = "gs"),
+    list(exp = glycomics_without_structure, level = "g"),
+    list(exp = complex_exp(), level = "gfs"),
+    list(exp = glycoproteomics_without_structure, level = "gf")
   )
 
-  expect_equal(
-    SummarizedExperiment::assay(glycomics),
-    SummarizedExperiment::assay(expected_glycomics)
-  )
-  expect_equal(
-    SummarizedExperiment::rowData(glycomics),
-    SummarizedExperiment::rowData(expected_glycomics)
-  )
-  expect_equal(
-    SummarizedExperiment::assay(glycoproteomics),
-    SummarizedExperiment::assay(expected_glycoproteomics)
-  )
-  expect_equal(
-    SummarizedExperiment::rowData(glycoproteomics),
-    SummarizedExperiment::rowData(expected_glycoproteomics)
-  )
+  for (case in cases) {
+    result <- aggregate(case$exp, standardize_variable = FALSE)
+    expected <- aggregate(
+      case$exp,
+      to_level = case$level,
+      standardize_variable = FALSE
+    )
+    expect_equal(
+      SummarizedExperiment::assay(result),
+      SummarizedExperiment::assay(expected)
+    )
+    expect_equal(
+      SummarizedExperiment::rowData(result),
+      SummarizedExperiment::rowData(expected)
+    )
+  }
 })
 
 test_that("aggregation preserves group order, missing-value sums, and metadata", {
@@ -159,7 +152,7 @@ test_that("glycomics aggregation supports legacy experiments", {
 
   expect_s3_class(result, "glyexp_experiment")
   expect_identical(result$meta_data$exp_type, "glycomics")
-  expect_equal(nrow(result$expr_mat), 2L)
+  expect_equal(nrow(result$expr_mat), 3L)
 })
 
 test_that("aggregation levels must match the experiment type", {

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -60,6 +60,96 @@ test_that("aggregation preserves group order, missing-value sums, and metadata",
   expect_false("charge" %in% colnames(result_var_info))
 })
 
+test_that("glycomics aggregation supports composition and structure levels", {
+  exp <- aggregation_glycomic_se()
+
+  compositions <- aggregate(exp, to_level = "g", standardize_variable = FALSE)
+  structures <- aggregate(exp, to_level = "gs", standardize_variable = FALSE)
+
+  expect_s4_class(compositions, "GlycomicSE")
+  expect_equal(
+    SummarizedExperiment::assay(compositions),
+    matrix(
+      c(6, 4, 18, 8),
+      nrow = 2,
+      dimnames = list(c("V1", "V2"), c("S1", "S2"))
+    )
+  )
+  expect_setequal(
+    colnames(SummarizedExperiment::rowData(compositions)),
+    "glycan_composition"
+  )
+
+  expect_s4_class(structures, "GlycomicSE")
+  expect_equal(
+    SummarizedExperiment::assay(structures),
+    matrix(
+      c(3, 3, 4, 11, 7, 8),
+      nrow = 3,
+      dimnames = list(paste0("V", 1:3), c("S1", "S2"))
+    )
+  )
+  expect_setequal(
+    colnames(SummarizedExperiment::rowData(structures)),
+    c("glycan_composition", "glycan_structure", "source")
+  )
+})
+
+test_that("glycomics aggregation supports legacy experiments", {
+  se <- aggregation_glycomic_se()
+  exp <- suppressWarnings(
+    glyexp::experiment(
+      SummarizedExperiment::assay(se),
+      sample_info = tibble::as_tibble(
+        SummarizedExperiment::colData(se),
+        rownames = "sample"
+      ),
+      var_info = tibble::as_tibble(
+        SummarizedExperiment::rowData(se),
+        rownames = "variable"
+      ),
+      exp_type = "glycomics",
+      glycan_type = "N"
+    )
+  )
+
+  result <- aggregate(exp, to_level = "gs", standardize_variable = FALSE)
+
+  expect_s3_class(result, "glyexp_experiment")
+  expect_identical(result$meta_data$exp_type, "glycomics")
+  expect_equal(nrow(result$expr_mat), 3L)
+})
+
+test_that("aggregation levels must match the experiment type", {
+  expect_snapshot(
+    aggregate(
+      aggregation_glycomic_se(),
+      to_level = "gf",
+      standardize_variable = FALSE
+    ),
+    error = TRUE
+  )
+  expect_snapshot(
+    aggregate(
+      complex_exp(),
+      to_level = "g",
+      standardize_variable = FALSE
+    ),
+    error = TRUE
+  )
+})
+
+test_that("glycomics structure aggregation requires glycan structures", {
+  expect_snapshot(
+    aggregate(
+      aggregation_glycomic_se(include_structure = FALSE),
+      to_level = "gs",
+      standardize_variable = FALSE
+    ),
+    error = TRUE
+  )
+})
+
 test_that("aggregating to glycopeptides (with structures) works", {
   exp <- real_exp()
   res <- aggregate(exp, to_level = "gps", standardize_variable = FALSE)

--- a/tests/testthat/test-auto-aggregate.R
+++ b/tests/testthat/test-auto-aggregate.R
@@ -1,46 +1,28 @@
-test_that("auto_aggregate works for glycoproteomics experiments", {
-  exp <- glyexp::as_glycoproteomic_se(glyexp::real_experiment)
-  suppressMessages(result_exp <- auto_aggregate(exp))
-  expect_glyco_se(result_exp)
-  expect_true(glyexp::is_glycoproteomic_se(result_exp))
-  expect_true(nrow(result_exp) < nrow(exp))
-})
-
-test_that("auto_aggregate works for glycomics experiments", {
+test_that("auto_aggregate is deprecated in favor of aggregate", {
+  withr::local_options(lifecycle_verbosity = "warning")
   exp <- aggregation_glycomic_se()
 
-  result_exp <- suppressMessages(
-    auto_aggregate(exp, standardize_variable = FALSE)
+  expect_snapshot(
+    result <- auto_aggregate(exp, standardize_variable = FALSE)
   )
-
-  expect_s4_class(result_exp, "GlycomicSE")
-  expect_equal(nrow(result_exp), 3L)
-  expect_true(
-    "glycan_structure" %in% colnames(SummarizedExperiment::rowData(result_exp))
-  )
+  expect_s4_class(result, "GlycomicSE")
 })
 
-test_that("auto_aggregate uses compositions for glycomics without structures", {
-  exp <- aggregation_glycomic_se(include_structure = FALSE)
+test_that("auto_aggregate delegates to aggregate", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  experiments <- list(aggregation_glycomic_se(), complex_exp())
 
-  result_exp <- suppressMessages(
-    auto_aggregate(exp, standardize_variable = FALSE)
-  )
-
-  expect_s4_class(result_exp, "GlycomicSE")
-  expect_equal(nrow(result_exp), 2L)
-  expect_setequal(
-    colnames(SummarizedExperiment::rowData(result_exp)),
-    "glycan_composition"
-  )
-})
-
-test_that("auto_aggregate works for experiments without glycan structure column", {
-  exp <- glyexp::as_glycoproteomic_se(glyexp::real_experiment)
-  SummarizedExperiment::rowData(exp)$glycan_structure <- NULL
-  suppressMessages(result_exp <- auto_aggregate(exp))
-  expect_setequal(
-    colnames(SummarizedExperiment::rowData(result_exp)),
-    c("protein", "gene", "glycan_composition", "protein_site")
-  )
+  for (exp in experiments) {
+    result <- auto_aggregate(exp, standardize_variable = FALSE)
+    expected <- aggregate(exp, standardize_variable = FALSE)
+    expect_identical(class(result), class(expected))
+    expect_equal(
+      SummarizedExperiment::assay(result),
+      SummarizedExperiment::assay(expected)
+    )
+    expect_equal(
+      SummarizedExperiment::rowData(result),
+      SummarizedExperiment::rowData(expected)
+    )
+  }
 })

--- a/tests/testthat/test-auto-aggregate.R
+++ b/tests/testthat/test-auto-aggregate.R
@@ -6,9 +6,33 @@ test_that("auto_aggregate works for glycoproteomics experiments", {
   expect_true(nrow(result_exp) < nrow(exp))
 })
 
-test_that("auto_aggregate rejects non-glycoproteomics experiments", {
-  exp <- glyexp::as_glycomic_se(glyexp::real_experiment2)
-  expect_snapshot(auto_aggregate(exp), error = TRUE)
+test_that("auto_aggregate works for glycomics experiments", {
+  exp <- aggregation_glycomic_se()
+
+  result_exp <- suppressMessages(
+    auto_aggregate(exp, standardize_variable = FALSE)
+  )
+
+  expect_s4_class(result_exp, "GlycomicSE")
+  expect_equal(nrow(result_exp), 3L)
+  expect_true(
+    "glycan_structure" %in% colnames(SummarizedExperiment::rowData(result_exp))
+  )
+})
+
+test_that("auto_aggregate uses compositions for glycomics without structures", {
+  exp <- aggregation_glycomic_se(include_structure = FALSE)
+
+  result_exp <- suppressMessages(
+    auto_aggregate(exp, standardize_variable = FALSE)
+  )
+
+  expect_s4_class(result_exp, "GlycomicSE")
+  expect_equal(nrow(result_exp), 2L)
+  expect_setequal(
+    colnames(SummarizedExperiment::rowData(result_exp)),
+    "glycan_composition"
+  )
 })
 
 test_that("auto_aggregate works for experiments without glycan structure column", {

--- a/tests/testthat/test-auto-clean.R
+++ b/tests/testthat/test-auto-clean.R
@@ -68,11 +68,14 @@ test_that("auto_clean works for glycomics data", {
     glycan_type = "N"
   )
 
-  expect_snapshot(result_exp <- auto_clean(test_exp))
+  expect_snapshot(
+    result_exp <- auto_clean(test_exp, standardize_variable = FALSE)
+  )
 
   expect_glyco_se(result_exp)
   expect_true(glyexp::is_glycomic_se(result_exp))
   expect_false(any(is.na(SummarizedExperiment::assay(result_exp))))
+  expect_equal(nrow(result_exp), 1L)
 })
 
 test_that("auto_clean works for glycomics data with QC", {
@@ -98,13 +101,14 @@ test_that("auto_clean works for glycomics data with QC", {
   )
 
   expect_snapshot(
-    result_exp <- auto_clean(test_exp),
+    result_exp <- auto_clean(test_exp, standardize_variable = FALSE),
     transform = sanitize_cv_snapshot
   )
 
   expect_glyco_se(result_exp)
   expect_true(glyexp::is_glycomic_se(result_exp))
   expect_false(any(is.na(SummarizedExperiment::assay(result_exp))))
+  expect_equal(nrow(result_exp), 1L)
 })
 
 test_that("auto_clean forwards batch_col to batch correction", {
@@ -116,7 +120,9 @@ test_that("auto_clean forwards batch_col to batch correction", {
   )
   var_info <- tibble::tibble(
     variable = paste0("V", 1:20),
-    glycan_composition = rep(glyrepr::glycan_composition(c(Hex = 1)), 20)
+    glycan_composition = glyrepr::as_glycan_composition(
+      paste0("H", 1:20, "N2")
+    )
   )
   expr_mat <- matrix(nrow = nrow(var_info), ncol = nrow(sample_info))
   colnames(expr_mat) <- sample_info$sample
@@ -138,14 +144,16 @@ test_that("auto_clean forwards batch_col to batch correction", {
     group_col = NULL,
     batch_col = "plate",
     batch_prop_threshold = 0,
-    check_batch_confounding = FALSE
+    check_batch_confounding = FALSE,
+    standardize_variable = FALSE
   ))
   result_without_batch <- suppressMessages(auto_clean(
     test_exp,
     group_col = NULL,
     batch_col = NULL,
     batch_prop_threshold = 0,
-    check_batch_confounding = FALSE
+    check_batch_confounding = FALSE,
+    standardize_variable = FALSE
   ))
 
   expect_false(isTRUE(all.equal(

--- a/tests/testthat/test-se-support.R
+++ b/tests/testthat/test-se-support.R
@@ -222,7 +222,7 @@ test_that("specialized glycoproteomics operations reject plain SummarizedExperim
 
   expect_error(
     aggregate(x, standardize_variable = FALSE),
-    message,
+    "must be a <glyexp_experiment>, <GlycomicSE>, or <GlycoproteomicSE> object",
     fixed = TRUE
   )
   expect_error(
@@ -237,16 +237,11 @@ test_that("specialized glycoproteomics operations reject plain SummarizedExperim
   )
 })
 
-test_that("specialized glycoproteomics operations distinguish glyco SE subclasses", {
+test_that("glycoproteomics-only operations distinguish glyco SE subclasses", {
   x <- simple_glycomic_se()
   message <- 'Got ("glycomics"|<GlycomicSE>)\\.'
 
   expect_error(
-    aggregate(x, standardize_variable = FALSE),
-    message,
-    fixed = FALSE
-  )
-  expect_error(
     adjust_protein(x, matrix(1)),
     message,
     fixed = FALSE
@@ -258,15 +253,10 @@ test_that("specialized glycoproteomics operations distinguish glyco SE subclasse
   )
 })
 
-test_that("specialized glycoproteomics operations retain experiment type errors", {
+test_that("glycoproteomics-only operations retain experiment type errors", {
   x <- glyexp::real_experiment2
   message <- 'Got ("glycomics"|<GlycomicSE>)\\.'
 
-  expect_error(
-    aggregate(x, standardize_variable = FALSE),
-    message,
-    fixed = FALSE
-  )
   expect_error(
     adjust_protein(x, matrix(1)),
     message,

--- a/tests/testthat/test-se-support.R
+++ b/tests/testthat/test-se-support.R
@@ -67,6 +67,7 @@ test_that("grouped preprocessing reads grouping variables from colData", {
 })
 
 test_that("automatic preprocessing preserves glyco SE subclasses", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   glycomic <- simple_glycomic_se()
   glycoproteomic <- simple_glycoproteomic_se()
 
@@ -148,6 +149,7 @@ test_that("plain SummarizedExperiment is always treated as others", {
 })
 
 test_that("type-specific automatic preprocessing rejects plain others SE", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   x <- plain_se(simple_glycomic_se())
 
   expect_error(
@@ -157,7 +159,7 @@ test_that("type-specific automatic preprocessing rejects plain others SE", {
   )
   expect_error(
     auto_aggregate(x, standardize_variable = FALSE),
-    "Must inherit from class 'glyexp_experiment', 'GlycomicSE', or 'GlycoproteomicSE'",
+    "`exp` must be a <glyexp_experiment>, <GlycomicSE>, or <GlycoproteomicSE> object.",
     fixed = TRUE
   )
 })

--- a/vignettes/glyclean.Rmd
+++ b/vignettes/glyclean.Rmd
@@ -104,12 +104,13 @@ auto_clean <- function(exp, ...) {
     exp <- auto_normalize(exp, ...)
     exp <- auto_remove(exp, ...)
     exp <- auto_impute(exp, ...)
-    exp <- auto_aggregate(exp)
+    exp <- glyclean::aggregate(exp)
     exp <- auto_normalize(exp, ...)
     exp <- auto_correct_batch_effect(exp, ...)
   } else if (glyexp::is_glycomic_se(exp)) {
     exp <- auto_remove(exp, ...)
     exp <- auto_impute(exp, ...)
+    exp <- glyclean::aggregate(exp)
     exp <- auto_normalize(exp, ...)
     exp <- auto_correct_batch_effect(exp, ...)
   } else {
@@ -124,7 +125,7 @@ As you can see, `auto_clean()` calls the following functions in sequence:
 - `auto_normalize()`: Automatically normalize the data
 - `auto_remove()`: Automatically remove variables with too many missing values
 - `auto_impute()`: Automatically impute the missing values
-- `auto_aggregate()`: Automatically aggregate the data
+- `aggregate()`: Aggregate automatically or to an explicitly selected level
 - `auto_correct_batch_effect()`: Automatically correct the batch effects
 
 These functions apply deterministic defaults for the given dataset.
@@ -144,7 +145,7 @@ clean_exp <- exp |>
   auto_remove() |>
   auto_normalize() |>
   auto_impute() |>
-  auto_aggregate()
+  glyclean::aggregate()
 ```
 
 ## Taking the Scenic Route: Step-by-Step Preprocessing 🚶‍♀️


### PR DESCRIPTION
Closes #22

## Summary

- Add `"g"` and `"gs"` aggregation levels for glycomics compositions and structures.
- Support both `GlycomicSE` and legacy glycomics experiments.
- Make `aggregate(to_level = NULL)` select `"gs"`/`"g"` for glycomics data and `"gfs"`/`"gf"` for glycoproteomics data based on whether `glycan_structure` is present.
- Keep `auto_aggregate()` as a deprecated compatibility wrapper around `aggregate()`.
- Add glycomics aggregation to `auto_clean()` after imputation and before normalization.
- Add type-specific validation, documentation, NEWS, and regression coverage.

## Verification

```r
exp <- glyexp::as_glycomic_se(glyexp::real_experiment2)

# Automatically chooses "gs" when glycan_structure is present.
glyclean::aggregate(
  exp,
  standardize_variable = FALSE
)

# Explicit levels remain supported.
glyclean::aggregate(
  exp,
  to_level = "g",
  standardize_variable = FALSE
)
```

- `devtools::test()` — 743 passed, 1 skipped; 2 pre-existing glyexp deprecation warnings
- `pkgdown::check_pkgdown()` — no problems
- `rmarkdown::render("vignettes/glyclean.Rmd")` — passed
- `devtools::check(document = FALSE, manual = FALSE, cran = FALSE)` — 0 errors, 0 warnings, 0 notes
