### PR TITLE
feat: add reproducible seeds to stochastic cleaning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # glyclean (development version)
 
 * `aggregate()` now supports glycomics levels `"g"` and `"gs"` and uses structure-aware defaults: `"gs"` or `"g"` for glycomics data and `"gfs"` or `"gf"` for glycoproteomics data, depending on whether `glycan_structure` is present. `auto_aggregate()` is deprecated in favor of `aggregate()`, and `auto_clean()` now aggregates glycomics data automatically. (#28)
+* Stochastic preprocessing functions now accept a reproducibility `seed`, with `auto_clean()` forwarding it through automatic imputation. (#29)
 
 # glyclean 0.15.2
 

--- a/R/auto-clean.R
+++ b/R/auto-clean.R
@@ -42,6 +42,8 @@
 #' @param standardize_variable Whether to call [glyexp::standardize_variable()]
 #'   after aggregation. Set to `FALSE` to skip network calls for faster testing.
 #'   Default is `TRUE`.
+#' @param seed Integer seed for random number generation used by stochastic
+#'   preprocessing steps. Default is `123`.
 #'
 #' @return A modified container with the same subclass as `exp`.
 #'
@@ -61,7 +63,8 @@ auto_clean <- function(
   batch_prop_threshold = 0.3,
   check_batch_confounding = TRUE,
   batch_confounding_threshold = 0.4,
-  standardize_variable = TRUE
+  standardize_variable = TRUE,
+  seed = 123
 ) {
   .assert_auto_container(exp)
   checkmate::assert_string(group_col, null.ok = TRUE)
@@ -70,6 +73,7 @@ auto_clean <- function(
   checkmate::assert_number(batch_prop_threshold, lower = 0, upper = 1)
   checkmate::assert_flag(check_batch_confounding)
   checkmate::assert_number(batch_confounding_threshold, lower = 0, upper = 1)
+  checkmate::assert_int(seed, lower = 0)
   exp_type <- .get_exp_type(exp)
   if (!checkmate::test_choice(exp_type, c("glycoproteomics", "glycomics"))) {
     cli::cli_abort(c(
@@ -85,7 +89,8 @@ auto_clean <- function(
     batch_prop_threshold = batch_prop_threshold,
     check_batch_confounding = check_batch_confounding,
     batch_confounding_threshold = batch_confounding_threshold,
-    standardize_variable = standardize_variable
+    standardize_variable = standardize_variable,
+    seed = seed
   )
   switch(
     .get_exp_type(exp),
@@ -113,7 +118,8 @@ auto_clean <- function(
   cli::cli_h2("Imputing missing values")
   exp <- auto_impute(
     exp,
-    params$group_col
+    params$group_col,
+    seed = params$seed
   )
   cli::cli_alert_success("Imputation completed.")
 
@@ -153,7 +159,8 @@ auto_clean <- function(
   cli::cli_h2("Imputing missing values")
   exp <- auto_impute(
     exp,
-    params$group_col
+    params$group_col,
+    seed = params$seed
   )
   cli::cli_alert_success("Imputation completed.")
 

--- a/R/auto-coda.R
+++ b/R/auto-coda.R
@@ -13,18 +13,37 @@
 #' @returns The input container with a CoDA-transformed expression matrix (ALR
 #'   if >50 variables, CLR otherwise) and its class preserved.
 #' @export
-auto_coda <- function(x, by = NULL, gamma = 0.1, group_scales = NULL) {
+auto_coda <- function(
+  x,
+  by = NULL,
+  gamma = 0.1,
+  group_scales = NULL,
+  seed = 123
+) {
   .assert_glyclean_container(x)
+  checkmate::assert_int(seed, lower = 0)
 
   if (nrow(x) > 50) {
     cli::cli_alert_info(
       "Data has more than 50 variables, using ALR transformation."
     )
-    transform_alr(x, by = by, gamma = gamma, group_scales = group_scales)
+    transform_alr(
+      x,
+      by = by,
+      gamma = gamma,
+      group_scales = group_scales,
+      seed = seed
+    )
   } else {
     cli::cli_alert_info(
       "Data has 50 or fewer variables, using CLR transformation."
     )
-    transform_clr(x, by = by, gamma = gamma, group_scales = group_scales)
+    transform_clr(
+      x,
+      by = by,
+      gamma = gamma,
+      group_scales = group_scales,
+      seed = seed
+    )
   }
 }

--- a/R/auto-impute.R
+++ b/R/auto-impute.R
@@ -21,6 +21,7 @@
 #'   [SummarizedExperiment::SummarizedExperiment()] object.
 #' @param group_col The column name in sample_info for groups. Default is "group".
 #'   Can be NULL when no group information is available.
+#' @param seed Integer seed for random number generation. Default is `123`.
 #'
 #' @returns The imputed input container, with its class preserved.
 #' @examples
@@ -29,13 +30,15 @@
 #' @export
 auto_impute <- function(
   exp,
-  group_col = "group"
+  group_col = "group",
+  seed = 123
 ) {
   # Check arguments
   .assert_glyclean_container(exp)
   checkmate::assert_string(group_col, null.ok = TRUE)
+  checkmate::assert_int(seed, lower = 0)
 
-  .auto_impute_default(exp)
+  .auto_impute_default(exp, seed = seed)
 }
 
 #' Apply the deterministic automatic imputation strategy
@@ -44,7 +47,7 @@ auto_impute <- function(
 #'
 #' @returns The imputed experiment.
 #' @noRd
-.auto_impute_default <- function(exp) {
+.auto_impute_default <- function(exp, seed = 123) {
   n_samples <- ncol(exp)
   exp_type <- .get_exp_type(exp)
   strategy <- .choose_auto_impute_strategy(n_samples, exp_type)
@@ -58,9 +61,9 @@ auto_impute <- function(
 
   switch(
     strategy$method_name,
-    impute_min_prob = impute_min_prob(exp),
+    impute_min_prob = impute_min_prob(exp, seed = seed),
     impute_bpca = impute_bpca(exp),
-    impute_miss_forest = impute_miss_forest(exp)
+    impute_miss_forest = impute_miss_forest(exp, seed = seed)
   )
 }
 

--- a/R/coda.R
+++ b/R/coda.R
@@ -56,18 +56,29 @@
 #'   this can be a single positive ratio for the second group relative to the
 #'   first, or two positive scales from which that ratio is derived. For
 #'   multi-group data, provide a positive vector with one scale per group.
+#' @param seed Integer seed for random number generation. Default is `123`.
 #'
 #' @return A container of the same class as `x`, with a transformed expression
 #'   matrix.
 #'   The returned values are back-transformed to the original ratio space.
 #'   Zeros in the input therefore remain zeros in the output.
 #' @export
-transform_clr <- function(x, by = NULL, gamma = 0.1, group_scales = NULL) {
-  .transform_clr_exp(
-    x,
-    by = by,
-    gamma = gamma,
-    group_scales = group_scales
+transform_clr <- function(
+  x,
+  by = NULL,
+  gamma = 0.1,
+  group_scales = NULL,
+  seed = 123
+) {
+  checkmate::assert_int(seed, lower = 0)
+  withr::with_seed(
+    seed,
+    .transform_clr_exp(
+      x,
+      by = by,
+      gamma = gamma,
+      group_scales = group_scales
+    )
   )
 }
 
@@ -92,12 +103,22 @@ transform_clr <- function(x, by = NULL, gamma = 0.1, group_scales = NULL) {
 #'   are back-transformed to the original ratio space, corresponding to
 #'   `x / x_ref`.
 #' @export
-transform_alr <- function(x, by = NULL, gamma = 0.1, group_scales = NULL) {
-  .transform_alr_exp(
-    x,
-    by = by,
-    gamma = gamma,
-    group_scales = group_scales
+transform_alr <- function(
+  x,
+  by = NULL,
+  gamma = 0.1,
+  group_scales = NULL,
+  seed = 123
+) {
+  checkmate::assert_int(seed, lower = 0)
+  withr::with_seed(
+    seed,
+    .transform_alr_exp(
+      x,
+      by = by,
+      gamma = gamma,
+      group_scales = group_scales
+    )
   )
 }
 

--- a/R/impute.R
+++ b/R/impute.R
@@ -122,12 +122,17 @@ impute_bpca <- function(x, by = NULL, ...) {
 #'   [SummarizedExperiment::SummarizedExperiment()] object.
 #' @param by Either a column name in `sample_info` (string) or a factor/vector
 #'   specifying group assignments for each sample. Used for grouping when imputing missing values.
+#' @param seed Integer seed for random number generation. Default is `123`.
 #' @param ... Additional arguments to pass to `pcaMethods::pca()`.
 #'
 #' @return A container of the same class as `x`, with missing values imputed.
 #' @export
-impute_ppca <- function(x, by = NULL, ...) {
-  .update_expr_mat(x, .impute_ppca, by = by, ...)
+impute_ppca <- function(x, by = NULL, seed = 123, ...) {
+  checkmate::assert_int(seed, lower = 0)
+  withr::with_seed(
+    seed,
+    .update_expr_mat(x, .impute_ppca, by = by, ...)
+  )
 }
 
 
@@ -165,19 +170,31 @@ impute_svd <- function(x, by = NULL, ...) {
 #'   sample. Default is `0.01`.
 #' @param tune.sigma Non-negative multiplier for the standard deviation of the
 #'   left-censored draw distribution. Default is `1`.
+#' @param seed Integer seed for random number generation. Default is `123`.
 #' @param ... Reserved for backward compatibility. Extra arguments are not
 #'   supported.
 #'
 #' @return A container of the same class as `x`, with missing values imputed.
 #' @export
-impute_min_prob <- function(x, by = NULL, q = 0.01, tune.sigma = 1, ...) {
-  .update_expr_mat(
-    x,
-    .impute_min_prob,
-    by = by,
-    q = q,
-    tune.sigma = tune.sigma,
-    ...
+impute_min_prob <- function(
+  x,
+  by = NULL,
+  q = 0.01,
+  tune.sigma = 1,
+  seed = 123,
+  ...
+) {
+  checkmate::assert_int(seed, lower = 0)
+  withr::with_seed(
+    seed,
+    .update_expr_mat(
+      x,
+      .impute_min_prob,
+      by = by,
+      q = q,
+      tune.sigma = tune.sigma,
+      ...
+    )
   )
 }
 
@@ -198,12 +215,15 @@ impute_min_prob <- function(x, by = NULL, q = 0.01, tune.sigma = 1, ...) {
 #' @return A container of the same class as `x`, with missing values imputed.
 #' @export
 impute_miss_forest <- function(x, by = NULL, seed = 123, ...) {
-  .update_expr_mat(
-    x,
-    .impute_miss_forest,
-    by = by,
-    seed = seed,
-    ...
+  checkmate::assert_int(seed, lower = 0)
+  withr::with_seed(
+    seed,
+    .update_expr_mat(
+      x,
+      .impute_miss_forest,
+      by = by,
+      ...
+    )
   )
 }
 
@@ -388,7 +408,7 @@ impute_miss_forest <- function(x, by = NULL, seed = 123, ...) {
 }
 
 
-.impute_miss_forest <- function(mat, seed, ...) {
+.impute_miss_forest <- function(mat, ...) {
   rlang::check_installed("missForest", reason = "to use `impute_miss_forest()`")
-  withr::with_seed(seed, missForest::missForest(mat, ...)$ximp)
+  missForest::missForest(mat, ...)$ximp
 }

--- a/R/impute.R
+++ b/R/impute.R
@@ -127,7 +127,7 @@ impute_bpca <- function(x, by = NULL, ...) {
 #'
 #' @return A container of the same class as `x`, with missing values imputed.
 #' @export
-impute_ppca <- function(x, by = NULL, seed = 123, ...) {
+impute_ppca <- function(x, by = NULL, ..., seed = 123) {
   checkmate::assert_int(seed, lower = 0)
   withr::with_seed(
     seed,
@@ -181,8 +181,8 @@ impute_min_prob <- function(
   by = NULL,
   q = 0.01,
   tune.sigma = 1,
-  seed = 123,
-  ...
+  ...,
+  seed = 123
 ) {
   checkmate::assert_int(seed, lower = 0)
   withr::with_seed(

--- a/R/qc.R
+++ b/R/qc.R
@@ -474,6 +474,7 @@ plot_batch_pca <- function(exp, batch_col = "batch") {
 #'   (e.g. `c("A", "A", "A", "B", "B", "B")` indicates three replicates for
 #'   sample A and three for sample B).
 #' @param n_pairs Number of replicate pairs to draw at random.
+#' @param seed Integer seed for random pair selection. Default is `123`.
 #'
 #' @returns A patchwork object containing replicate scatter plots.
 #'
@@ -486,10 +487,11 @@ plot_batch_pca <- function(exp, batch_col = "batch") {
 #' plot_rep_scatter(exp, rep_col = "replicate", n_pairs = 4)
 #'
 #' @export
-plot_rep_scatter <- function(exp, rep_col, n_pairs = 9) {
+plot_rep_scatter <- function(exp, rep_col, n_pairs = 9, seed = 123) {
   .assert_glyclean_container(exp)
   checkmate::assert_string(rep_col)
   checkmate::assert_int(n_pairs, lower = 1)
+  checkmate::assert_int(seed, lower = 0)
   rlang::check_installed("patchwork", reason = "to use `plot_rep_scatter()`")
 
   mat <- .get_expr_mat(exp)
@@ -538,7 +540,10 @@ plot_rep_scatter <- function(exp, rep_col, n_pairs = 9) {
     n_pairs <- length(pairs)
   }
 
-  selected_pairs <- pairs[sample.int(length(pairs), size = n_pairs)]
+  selected_pairs <- withr::with_seed(
+    seed,
+    pairs[sample.int(length(pairs), size = n_pairs)]
+  )
 
   log_mat <- .log2_matrix(mat, sample_names = sample_names)
 

--- a/man/auto_clean.Rd
+++ b/man/auto_clean.Rd
@@ -12,7 +12,8 @@ auto_clean(
   batch_prop_threshold = 0.3,
   check_batch_confounding = TRUE,
   batch_confounding_threshold = 0.4,
-  standardize_variable = TRUE
+  standardize_variable = TRUE,
+  seed = 123
 )
 }
 \arguments{
@@ -46,6 +47,9 @@ Only used when \code{check_batch_confounding} is TRUE. Default to 0.4.}
 \item{standardize_variable}{Whether to call \code{\link[glyexp:standardize_variable]{glyexp::standardize_variable()}}
 after aggregation. Set to \code{FALSE} to skip network calls for faster testing.
 Default is \code{TRUE}.}
+
+\item{seed}{Integer seed for random number generation used by stochastic
+preprocessing steps. Default is \code{123}.}
 }
 \value{
 A modified container with the same subclass as \code{exp}.

--- a/man/auto_coda.Rd
+++ b/man/auto_coda.Rd
@@ -4,7 +4,7 @@
 \alias{auto_coda}
 \title{Automatical CoDA transformation}
 \usage{
-auto_coda(x, by = NULL, gamma = 0.1, group_scales = NULL)
+auto_coda(x, by = NULL, gamma = 0.1, group_scales = NULL, seed = 123)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -20,6 +20,8 @@ scale. Default is \code{0.1}. Set to \code{0} for deterministic transformation.}
 this can be a single positive ratio for the second group relative to the
 first, or two positive scales from which that ratio is derived. For
 multi-group data, provide a positive vector with one scale per group.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 }
 \value{
 The input container with a CoDA-transformed expression matrix (ALR

--- a/man/auto_impute.Rd
+++ b/man/auto_impute.Rd
@@ -4,7 +4,7 @@
 \alias{auto_impute}
 \title{Automatic Imputation}
 \usage{
-auto_impute(exp, group_col = "group")
+auto_impute(exp, group_col = "group", seed = 123)
 }
 \arguments{
 \item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -12,6 +12,8 @@ auto_impute(exp, group_col = "group")
 
 \item{group_col}{The column name in sample_info for groups. Default is "group".
 Can be NULL when no group information is available.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 }
 \value{
 The imputed input container, with its class preserved.

--- a/man/impute_min_prob.Rd
+++ b/man/impute_min_prob.Rd
@@ -4,7 +4,7 @@
 \alias{impute_min_prob}
 \title{Minimum Probability Imputation}
 \usage{
-impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1, ...)
+impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1, seed = 123, ...)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -18,6 +18,8 @@ sample. Default is \code{0.01}.}
 
 \item{tune.sigma}{Non-negative multiplier for the standard deviation of the
 left-censored draw distribution. Default is \code{1}.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 
 \item{...}{Reserved for backward compatibility. Extra arguments are not
 supported.}

--- a/man/impute_min_prob.Rd
+++ b/man/impute_min_prob.Rd
@@ -4,7 +4,7 @@
 \alias{impute_min_prob}
 \title{Minimum Probability Imputation}
 \usage{
-impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1, seed = 123, ...)
+impute_min_prob(x, by = NULL, q = 0.01, tune.sigma = 1, ..., seed = 123)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -19,10 +19,10 @@ sample. Default is \code{0.01}.}
 \item{tune.sigma}{Non-negative multiplier for the standard deviation of the
 left-censored draw distribution. Default is \code{1}.}
 
-\item{seed}{Integer seed for random number generation. Default is \code{123}.}
-
 \item{...}{Reserved for backward compatibility. Extra arguments are not
 supported.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 }
 \value{
 A container of the same class as \code{x}, with missing values imputed.

--- a/man/impute_ppca.Rd
+++ b/man/impute_ppca.Rd
@@ -4,7 +4,7 @@
 \alias{impute_ppca}
 \title{PPCA Imputation}
 \usage{
-impute_ppca(x, by = NULL, seed = 123, ...)
+impute_ppca(x, by = NULL, ..., seed = 123)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -13,9 +13,9 @@ impute_ppca(x, by = NULL, seed = 123, ...)
 \item{by}{Either a column name in \code{sample_info} (string) or a factor/vector
 specifying group assignments for each sample. Used for grouping when imputing missing values.}
 
-\item{seed}{Integer seed for random number generation. Default is \code{123}.}
-
 \item{...}{Additional arguments to pass to \code{pcaMethods::pca()}.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 }
 \value{
 A container of the same class as \code{x}, with missing values imputed.

--- a/man/impute_ppca.Rd
+++ b/man/impute_ppca.Rd
@@ -4,7 +4,7 @@
 \alias{impute_ppca}
 \title{PPCA Imputation}
 \usage{
-impute_ppca(x, by = NULL, ...)
+impute_ppca(x, by = NULL, seed = 123, ...)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -12,6 +12,8 @@ impute_ppca(x, by = NULL, ...)
 
 \item{by}{Either a column name in \code{sample_info} (string) or a factor/vector
 specifying group assignments for each sample. Used for grouping when imputing missing values.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 
 \item{...}{Additional arguments to pass to \code{pcaMethods::pca()}.}
 }

--- a/man/plot_rep_scatter.Rd
+++ b/man/plot_rep_scatter.Rd
@@ -4,7 +4,7 @@
 \alias{plot_rep_scatter}
 \title{Plot Replicate Scatter Plots}
 \usage{
-plot_rep_scatter(exp, rep_col, n_pairs = 9)
+plot_rep_scatter(exp, rep_col, n_pairs = 9, seed = 123)
 }
 \arguments{
 \item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -16,6 +16,8 @@ Samples with the same value in this column are treated as replicates
 sample A and three for sample B).}
 
 \item{n_pairs}{Number of replicate pairs to draw at random.}
+
+\item{seed}{Integer seed for random pair selection. Default is \code{123}.}
 }
 \value{
 A patchwork object containing replicate scatter plots.

--- a/man/transform_alr.Rd
+++ b/man/transform_alr.Rd
@@ -4,7 +4,7 @@
 \alias{transform_alr}
 \title{Additive Log-Ratio Transformation}
 \usage{
-transform_alr(x, by = NULL, gamma = 0.1, group_scales = NULL)
+transform_alr(x, by = NULL, gamma = 0.1, group_scales = NULL, seed = 123)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -20,6 +20,8 @@ scale. Default is \code{0.1}. Set to \code{0} for deterministic transformation.}
 this can be a single positive ratio for the second group relative to the
 first, or two positive scales from which that ratio is derived. For
 multi-group data, provide a positive vector with one scale per group.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 }
 \value{
 A container of the same class as \code{x}, with an ALR-transformed

--- a/man/transform_clr.Rd
+++ b/man/transform_clr.Rd
@@ -4,7 +4,7 @@
 \alias{transform_clr}
 \title{Centered Log-Ratio Transformation}
 \usage{
-transform_clr(x, by = NULL, gamma = 0.1, group_scales = NULL)
+transform_clr(x, by = NULL, gamma = 0.1, group_scales = NULL, seed = 123)
 }
 \arguments{
 \item{x}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, or
@@ -20,6 +20,8 @@ scale. Default is \code{0.1}. Set to \code{0} for deterministic transformation.}
 this can be a single positive ratio for the second group relative to the
 first, or two positive scales from which that ratio is derived. For
 multi-group data, provide a positive vector with one scale per group.}
+
+\item{seed}{Integer seed for random number generation. Default is \code{123}.}
 }
 \value{
 A container of the same class as \code{x}, with a transformed expression

--- a/tests/testthat/test-auto-clean.R
+++ b/tests/testthat/test-auto-clean.R
@@ -10,6 +10,24 @@ test_that("auto_clean works for glycoproteomics data", {
   expect_false(any(is.na(SummarizedExperiment::assay(result_exp))))
 })
 
+test_that("auto_clean is reproducible with its seed", {
+  first <- suppressMessages(auto_clean(
+    complex_exp(),
+    standardize_variable = FALSE,
+    seed = 17
+  ))
+  second <- suppressMessages(auto_clean(
+    complex_exp(),
+    standardize_variable = FALSE,
+    seed = 17
+  ))
+
+  expect_identical(
+    SummarizedExperiment::assay(first),
+    SummarizedExperiment::assay(second)
+  )
+})
+
 test_that("auto_clean works for glycoproteomics data with QC", {
   set.seed(123)
   test_exp <- complex_exp()

--- a/tests/testthat/test-coda.R
+++ b/tests/testthat/test-coda.R
@@ -102,6 +102,17 @@ test_that("transform_clr samples per-feature noise on the log2 scale", {
   expect_equal(unname(result_mat[, 1]), 2^(c(2, 4) + expected_noise))
 })
 
+test_that("public CoDA transforms are reproducible with their seed", {
+  test_exp <- simple_exp(3, 3)
+  first <- transform_clr(test_exp, seed = 17)
+  second <- transform_clr(test_exp, seed = 17)
+
+  expect_identical(
+    SummarizedExperiment::assay(first),
+    SummarizedExperiment::assay(second)
+  )
+})
+
 test_that("transform_clr ignores group scales when gamma is zero", {
   test_mat <- matrix(
     c(

--- a/tests/testthat/test-impute.R
+++ b/tests/testthat/test-impute.R
@@ -119,6 +119,27 @@ test_that("impute_min_prob works", {
   expect_equal(sum(is.na(SummarizedExperiment::assay(result_exp))), 0)
 })
 
+test_that("impute_min_prob is reproducible with its seed", {
+  first <- impute_min_prob(old_test_exp, seed = 42)
+  second <- impute_min_prob(old_test_exp, seed = 42)
+
+  expect_identical(
+    SummarizedExperiment::assay(first),
+    SummarizedExperiment::assay(second)
+  )
+})
+
+test_that("impute_ppca is reproducible with its seed", {
+  skip_if_not_installed("pcaMethods")
+  first <- suppressWarnings(impute_ppca(old_test_exp, seed = 42))
+  second <- suppressWarnings(impute_ppca(old_test_exp, seed = 42))
+
+  expect_identical(
+    SummarizedExperiment::assay(first),
+    SummarizedExperiment::assay(second)
+  )
+})
+
 test_that("impute_min_prob uses left-censored log-scale draws", {
   test_mat <- matrix(
     c(
@@ -217,6 +238,17 @@ test_that("impute_miss_forest works", {
   skip_if_not_installed("missForest")
   result_exp <- impute_miss_forest(test_exp)
   expect_equal(sum(is.na(SummarizedExperiment::assay(result_exp))), 0)
+})
+
+test_that("impute_miss_forest is reproducible with its seed", {
+  skip_if_not_installed("missForest")
+  first <- impute_miss_forest(old_test_exp, seed = 42)
+  second <- impute_miss_forest(old_test_exp, seed = 42)
+
+  expect_identical(
+    SummarizedExperiment::assay(first),
+    SummarizedExperiment::assay(second)
+  )
 })
 
 

--- a/tests/testthat/test-impute.R
+++ b/tests/testthat/test-impute.R
@@ -140,6 +140,20 @@ test_that("impute_ppca is reproducible with its seed", {
   )
 })
 
+test_that("impute_ppca preserves positional pca arguments", {
+  skip_if_not_installed("pcaMethods")
+  test_exp <- missing_exp_10_10()
+
+  result <- suppressWarnings(impute_ppca(
+    test_exp,
+    NULL,
+    "none",
+    seed = 42
+  ))
+
+  expect_equal(sum(is.na(SummarizedExperiment::assay(result))), 0)
+})
+
 test_that("impute_min_prob uses left-censored log-scale draws", {
   test_mat <- matrix(
     c(


### PR DESCRIPTION
## Summary
Adds default `seed = 123` controls to stochastic imputation, CoDA, plotting, and automatic-cleaning paths. Seeded operations use `withr::with_seed()` and `auto_clean()` forwards its seed through `auto_impute()`.

## Verification
- `devtools::test()`: 747 passed, 1 skipped
- `pkgdown::check_pkgdown()`: passed
- `devtools::check(args = "--no-manual")`: 0 errors, 0 warnings (one environment clock note)